### PR TITLE
Add rtionplan support redux

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -1,0 +1,31 @@
+name: Python application
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Lint with flake8
+      run: |
+        pip install flake8
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        pip install pytest
+        pytest 
+

--- a/src/View/ProgressBar.py
+++ b/src/View/ProgressBar.py
@@ -133,6 +133,8 @@ class Extended(QtCore.QThread):
 
         # For each file in path
         for file in dcm_files:
+            if (os.path.isdir(file)):
+                continue
             try:
                 read_file = pydicom.dcmread(file, force=True)
             except:
@@ -150,6 +152,10 @@ class Extended(QtCore.QThread):
                         self.read_data_dict['rtdose'] = read_file
                         self.file_names_dict['rtdose'] = file
                     elif read_file.SOPClassUID == '1.2.840.10008.5.1.4.1.1.481.5':
+                        self.read_data_dict['rtplan'] = read_file
+                        self.file_names_dict['rtplan'] = file
+                    # RT Ion Plan
+                    elif read_file.SOPClassUID == '1.2.840.10008.5.1.4.1.1.481.8':
                         self.read_data_dict['rtplan'] = read_file
                         self.file_names_dict['rtplan'] = file
                     self.copied += len(read_file)

--- a/test/test_model_roi.py
+++ b/test/test_model_roi.py
@@ -1,0 +1,20 @@
+"""
+Created on Thu Dec  5 05:25:04 2019
+
+@author: sjswerdloff
+"""
+
+from src.Model.ROI import calculate_matrix
+from pydicom import dataset
+import numpy as np
+
+def test_calculate_matrix():
+    image_ds= dataset.Dataset()
+    image_ds.PixelSpacing = [1,1]
+    image_ds.ImageOrientationPatient=[1,0,0,0,1,0] 
+    image_ds.ImagePositionPatient=[0,0,0]  
+    image_ds.Rows=4
+    image_ds.Columns=4
+    array_x, array_y= calculate_matrix(image_ds)
+    assert( np.all(array_x == np.array([0,1,2,3])) )
+    assert( np.all(array_y == np.array([0,1,2,3])) )


### PR DESCRIPTION
adds the SOP Class UID for RT Ion Plan as a consumable 'rtplan' Dataset given the current usage of the Dataset in OnkoDICOM (tested against private copy of an RT Ion Plan based dataset).
Adds a simple unit test for Model.ROI.calculate_matrix() to test directory
Adds a github action using the default pythonapp.yml from github, which passes in part because the unit test ensures that there are more than zero tests.
Accepting this Pull Request will result in future OnkoDICOM Pull Requests triggering the action and enforcing flake8 and pytest
