### PR TITLE
add Darwin as a platform so that calculation and assignment of a rawd…

### DIFF
--- a/src/View/ProgressBar.py
+++ b/src/View/ProgressBar.py
@@ -65,6 +65,9 @@ class Extended(QtCore.QThread):
             elif self.platform == 'Windows':
                 self.raw_dvh = self.single_calc_dvhs(
                     self.dataset_rtss, self.dataset_rtdose, self.rois, self.my_callback)
+            elif self.platform == 'Darwin':
+                self.raw_dvh = self.single_calc_dvhs(
+                    self.dataset_rtss, self.dataset_rtdose, self.rois, self.my_callback)
             # self.raw_dvh = self.calc_dvhs(
             #     self.dataset_rtss, self.dataset_rtdose, self.rois, self.my_callback)
             self.dvh_x_y = self.converge_to_O_dvh(


### PR DESCRIPTION
add Darwin as a platform so that calculation and assignment of a rawdvh will take place on MacOS
without the rawdvh, application crashes on MacOS
similar issue as Windows where the single process approach is required.

The error message on MacOS (Catalina/10.15.2) when using the multiprocess approach was:
The process has forked and you cannot use this CoreFoundation functionality safely. You MUST exec().
Break on __THE_PROCESS_HAS_FORKED_AND_YOU_CANNOT_USE_THIS_COREFOUNDATION_FUNCTIONALITY___YOU_MUST_EXEC__() to debug.

