### PR TITLE
Fix DICOM Tree tab displays files not part of dataset

### DIFF
--- a/src/View/mainpage/DicomTree.py
+++ b/src/View/mainpage/DicomTree.py
@@ -90,8 +90,10 @@ class DicomTreeUI(object):
 							   "background-color: #efefef; }"
 							   )
 		combobox.addItem("Select a DICOM dataset...")
-		combobox.addItem("RT Dose")
-		combobox.addItem("RTSS")
+		if self.window.has_rtss:
+			combobox.addItem("RT Dose")
+			combobox.addItem("RTSS")
+
 		for i in range(len(self.pixmaps) - 1):
 			combobox.addItem("CT Image Slice " + str(i + 1))
 		combobox.activated.connect(self.item_selected)


### PR DESCRIPTION
Due to the hardcoded nature of the DICOM tree tab, when files such as RTSTRUCT and RTDOSE are not loaded into the program they will still display as options in the dropdown menu. Selecting these will crash the program. Additionally, all image files will be labelled as CT slices, even if the slices are not CT images.

So I put combobox.addItem RTDose and RTStruct in mainwindow.has_rtss condition, that solved the above error.