### PR TITLE
[ROIDelete] MenuBar.py: Local variable 'confirmation_dialog' referneced before assignment

### DIFF
--- a/src/View/mainpage/MenuBar.py
+++ b/src/View/mainpage/MenuBar.py
@@ -437,9 +437,8 @@ class MenuHandler(object):
 			confirmation_dialog = QMessageBox.information(self.main_window, 'Unable to open ROI Delete Window',
 														  'This patient does not contain RTSS',
 														  QMessageBox.Ok)
-
-		if confirmation_dialog == QtWidgets.QMessageBox.Ok:
-			pass
+			if confirmation_dialog == QtWidgets.QMessageBox.Ok:
+				pass
 
 	def actionExit(self):
 		sys.exit()


### PR DESCRIPTION
In MenuBar.py, the use of confirmation_dialog was originally outside of if-else statement that checking has_rtss.
So when selecting ROI Delete option, if the patient has_rtss, the program will crash because confirmation_dialog is not referenced.

