### PR TITLE
Main script now accepts default directory from drag and drop

### DIFF
--- a/main.py
+++ b/main.py
@@ -26,17 +26,17 @@ if __name__ == "__main__":
     app = QtWidgets.QApplication(sys.argv)
 
     print("PDPI: " + str(app.primaryScreen().physicalDotsPerInch()))
-    # app_font = QFont()
-    # app_font.setFamily(FontService.get_instance().font_family())
-    # app_font.setPixelSize(FontService.get_instance().get_scaled_font_pixel_size(app, 10))
-    # app.setFont(app_font)
-
 
     # Set the font to Segoe UI, 9, when in windows OS
     if platform.system() == 'Windows':
         f = QFont("Segoe UI", 9)
         app.setFont(f)
 
-    controller = Controller()
-    controller.show_welcome()
+    if len(sys.argv) > 1:
+        controller = Controller(default_directory=sys.argv[1])
+        controller.show_open_patient()
+    else:
+        controller = Controller()
+        controller.show_welcome()
+
     sys.exit(app.exec_())

--- a/src/Controller/GUIController.py
+++ b/src/Controller/GUIController.py
@@ -30,10 +30,15 @@ class OpenPatientWindow(QtWidgets.QMainWindow, UIOpenPatientWindow):
     go_next_window = QtCore.pyqtSignal(tuple)
 
     # Initialisation function to display the UI
-    def __init__(self):
+    def __init__(self, default_directory):
         QtWidgets.QMainWindow.__init__(self)
         self.setup_ui(self)
         self.patient_info_initialized.connect(self.open_patient)
+
+        if default_directory is not None:
+            self.filepath = default_directory
+            self.open_patient_directory_input_box.setText(default_directory)
+            self.scan_directory_for_patient()
 
     def open_patient(self, patient_attributes):
         self.go_next_window.emit(patient_attributes)

--- a/src/Controller/TopLevelController.py
+++ b/src/Controller/TopLevelController.py
@@ -6,11 +6,13 @@ from src.Controller.GUIController import WelcomeWindow, OpenPatientWindow, MainW
 class Controller:
 
     # Initialisation function that creates an instance of each window
-    def __init__(self):
+    def __init__(self, default_directory=None):
         self.welcome_window = QtWidgets.QMainWindow()
         self.open_patient_window = QtWidgets.QMainWindow()
         self.main_window = QtWidgets.QMainWindow()
         self.pyradi_progressbar = QtWidgets.QWidget()
+        self.default_directory = default_directory  # This will contain a filepath of a folder that is dragged onto
+        # the executable icon
 
     def show_welcome(self):
         """
@@ -30,7 +32,7 @@ class Controller:
         if self.main_window.isVisible():
             self.main_window.close()
 
-        self.open_patient_window = OpenPatientWindow()
+        self.open_patient_window = OpenPatientWindow(self.default_directory)
         self.open_patient_window.patient_info_initialized.connect(self.show_main_window)
         self.open_patient_window.show()
 


### PR DESCRIPTION
This allows the end user to drag and drop a folder onto OnkoDICOM's script in order to skip the welcome window and have that folder loaded automatically.  This has been tested to work on main.py _and_ the windows executable.