### PR TITLE
Improvements to saving modified RTSTRUCT.

### DIFF
--- a/src/View/mainpage/StructureTab.py
+++ b/src/View/mainpage/StructureTab.py
@@ -256,7 +256,12 @@ class StructureTab(QtWidgets.QWidget):
 
         self.modified_indicator_widget.setLayout(modified_indicator_layout)
         self.modified_indicator_widget.mouseReleaseEvent = self.save_new_rtss  # When the widget is clicked, save the rtss
+
+        # Temporarily remove the ROI modify buttons, add this indicator, then add them back again.
+        # This ensure that the modifier appears above the ROI modify buttons.
+        self.structure_tab_layout.removeWidget(self.roi_buttons)
         self.structure_tab_layout.addWidget(self.modified_indicator_widget)
+        self.structure_tab_layout.addWidget(self.roi_buttons)
 
     def structure_checked(self, state, roi_id):
         """

--- a/src/View/mainpage/StructureTab.py
+++ b/src/View/mainpage/StructureTab.py
@@ -187,7 +187,7 @@ class StructureTab(QtWidgets.QWidget):
 
         # If this is the first time the RTSS has been modified, create a modified indicator giving the user the option
         # to save their new file.
-        if not self.patient_dict_container.get("rtss_modified"):
+        if self.patient_dict_container.get("rtss_modified") is False:
             self.show_modified_indicator()
 
         # If this is the first change made to the RTSS file, update the dataset with the new one so that OnkoDICOM
@@ -241,8 +241,8 @@ class StructureTab(QtWidgets.QWidget):
         self.update_content()
 
     def show_modified_indicator(self):
-        modified_indicator_widget = QtWidgets.QWidget()
-        modified_indicator_widget.setContentsMargins(8, 5, 8, 5)
+        self.modified_indicator_widget = QtWidgets.QWidget()
+        self.modified_indicator_widget.setContentsMargins(8, 5, 8, 5)
         modified_indicator_layout = QtWidgets.QHBoxLayout()
         modified_indicator_layout.setAlignment(QtCore.Qt.AlignLeft)
 
@@ -254,9 +254,9 @@ class StructureTab(QtWidgets.QWidget):
         modified_indicator_text.setStyleSheet("color: red")
         modified_indicator_layout.addWidget(modified_indicator_text)
 
-        modified_indicator_widget.setLayout(modified_indicator_layout)
-        modified_indicator_widget.mouseReleaseEvent = self.save_new_rtss  # When the widget is clicked, save the rtss
-        self.structure_tab_layout.addWidget(modified_indicator_widget)
+        self.modified_indicator_widget.setLayout(modified_indicator_layout)
+        self.modified_indicator_widget.mouseReleaseEvent = self.save_new_rtss  # When the widget is clicked, save the rtss
+        self.structure_tab_layout.addWidget(self.modified_indicator_widget)
 
     def structure_checked(self, state, roi_id):
         """
@@ -290,3 +290,4 @@ class StructureTab(QtWidgets.QWidget):
             self.patient_dict_container.get("dataset_rtss").save_as(rtss_directory)
             QtWidgets.QMessageBox.about(self.parentWidget(), "File saved", "The RTSTRUCT file has been saved.")
             self.patient_dict_container.set("rtss_modified", False)
+            self.modified_indicator_widget.setParent(None)

--- a/src/View/mainpage/StructureTab.py
+++ b/src/View/mainpage/StructureTab.py
@@ -279,10 +279,14 @@ class StructureTab(QtWidgets.QWidget):
         self.request_update_structures.emit()
 
     def save_new_rtss(self, event=None):
-        rtss_directory = str(Path(self.patient_dict_container.get("file_rtss")).parent)
-        save_filepath = save_filepath = QtWidgets.QFileDialog.getSaveFileName(self.parentWidget(), "Save file",
-                                                                              rtss_directory)[0]
-        if save_filepath != "":
-            self.patient_dict_container.get("dataset_rtss").save_as(save_filepath)
+        rtss_directory = str(Path(self.patient_dict_container.get("file_rtss")))
+
+        confirm_save = QtWidgets.QMessageBox.information(self, "Confirmation",
+                                                 "Are you sure you want to save the modified RTSTRUCT file? This will "
+                                                 "overwrite the existing file. This is not reversible.",
+                                                 QtWidgets.QMessageBox.Yes, QtWidgets.QMessageBox.No)
+
+        if confirm_save == QtWidgets.QMessageBox.Yes:
+            self.patient_dict_container.get("dataset_rtss").save_as(rtss_directory)
             QtWidgets.QMessageBox.about(self.parentWidget(), "File saved", "The RTSTRUCT file has been saved.")
             self.patient_dict_container.set("rtss_modified", False)


### PR DESCRIPTION
This branch introduces the following:
- Saving RTSTRUCT no longer asks for a user file path. Instead, it now overwrites the existing RTSTRUCT file. The user is warned of this when they save.
- Fixed a bug that made multiple modified indicators appear on top of eachother when making multiple changes to the structures.
- The structure modified indicator now appears above the ROI Draw/Delete buttons.