### PR TITLE
Added save action

### DIFF
--- a/src/Controller/ActionHandler.py
+++ b/src/Controller/ActionHandler.py
@@ -32,6 +32,19 @@ class ActionHandler:
         self.action_open.setText("Open new patient")
         self.action_open.setIconVisibleInMenu(True)
 
+        # Save RTSTRUCT changes action
+        self.icon_save_structure = QtGui.QIcon()
+        self.icon_save_structure.addPixmap(
+            QtGui.QPixmap(resource_path("src/res/images/btn-icons/save_all_purple_icon.png")),
+            QtGui.QIcon.Normal,
+            QtGui.QIcon.On
+        )
+        self.action_save_structure = QtWidgets.QAction()
+        self.action_save_structure.setIcon(self.icon_save_structure)
+        self.action_save_structure.setText("Save RTSTRUCT changes")
+        self.action_save_structure.setIconVisibleInMenu(True)
+        self.action_save_structure.triggered.connect(self.save_struct_handler)
+
         # Save as Anonymous Action
         self.icon_save_as_anonymous = QtGui.QIcon()
         self.icon_save_as_anonymous.addPixmap(
@@ -166,6 +179,15 @@ class ActionHandler:
         # Feel free to try fix (or at least explain why the action has to be set as the windowing menu's child twice)
         for item in windowing_actions:
             self.menu_windowing.addAction(item)
+
+    def save_struct_handler(self):
+        """
+        If there are changes to the RTSTRUCT detected, save the changes to disk.
+        """
+        if self.patient_dict_container.get("rtss_modified"):
+            self.__main_page.structures_tab.save_new_rtss()
+        else:
+            QtWidgets.QMessageBox.Information(self, "File not saved", "No changes to the RTSTRUCT file detected.")
 
     def windowing_handler(self, state, text):
         """

--- a/src/Controller/ActionHandler.py
+++ b/src/Controller/ActionHandler.py
@@ -187,7 +187,8 @@ class ActionHandler:
         if self.patient_dict_container.get("rtss_modified"):
             self.__main_page.structures_tab.save_new_rtss()
         else:
-            QtWidgets.QMessageBox.Information(self, "File not saved", "No changes to the RTSTRUCT file detected.")
+            QtWidgets.QMessageBox.information(self.__main_page, "File not saved",
+                                              "No changes to the RTSTRUCT file detected.")
 
     def windowing_handler(self, state, text):
         """

--- a/src/View/mainpage/MenuBar.py
+++ b/src/View/mainpage/MenuBar.py
@@ -4,14 +4,15 @@ from PyQt5 import QtWidgets, QtCore
 from PyQt5.QtCore import Qt
 
 from src.Controller.ActionHandler import ActionHandler
+from src.Model.PatientDictContainer import PatientDictContainer
 
 
-# TODO this class needs to be able to recognise when an RTSTRUCT/DVH is present, and add new actions accordingly
 class MenuBar(QtWidgets.QMenuBar):
 
     def __init__(self, action_handler: ActionHandler):
         QtWidgets.QMenuBar.__init__(self)
         self.action_handler = action_handler
+        self.patient_dict_container = PatientDictContainer()
         self.setGeometry(QtCore.QRect(0, 0, 901, 35))
         self.setContextMenuPolicy(Qt.PreventContextMenu)
 
@@ -36,6 +37,8 @@ class MenuBar(QtWidgets.QMenuBar):
         # Add actions to File menu
         self.menu_file.addAction(self.action_handler.action_open)
         self.menu_file.addSeparator()
+        if self.patient_dict_container.has_modality('rtss'):
+            self.menu_file.addAction(self.action_handler.action_save_structure)
         self.menu_file.addAction(self.action_handler.action_save_as_anonymous)
         self.menu_file.addSeparator()
         self.menu_file.addAction(self.action_handler.action_exit)

--- a/src/View/mainpage/Toolbar.py
+++ b/src/View/mainpage/Toolbar.py
@@ -4,6 +4,7 @@ from PyQt5.QtGui import QCursor
 from PyQt5.QtWidgets import QToolBar, QToolButton, QWidget, QSizePolicy
 
 from src.Controller.ActionHandler import ActionHandler
+from src.Model.PatientDictContainer import PatientDictContainer
 
 
 class Toolbar(QToolBar):
@@ -11,6 +12,7 @@ class Toolbar(QToolBar):
     def __init__(self, action_handler: ActionHandler):
         QToolBar.__init__(self)
         self.action_handler = action_handler
+        self.patient_dict_container = PatientDictContainer()
         self.setCursor(QCursor(Qt.PointingHandCursor))
         self.setMovable(False)
         self.setFloatable(False)
@@ -47,3 +49,5 @@ class Toolbar(QToolBar):
         self.addWidget(spacer)
         self.addWidget(self.button_export)
         self.addAction(self.action_handler.action_save_as_anonymous)
+        if self.patient_dict_container.has_modality('rtss'):
+            self.addAction(self.action_handler.action_save_structure)


### PR DESCRIPTION
When an RTSTRUCT is present, a new Save Structure Changes button has been added to the toolbar and menubar. This is an alternative way for the user to save structures beyond the current options of clicking the modified structures indicator, or closing the current patient session.