### PR TITLE
User is now informed when DVH values are outdated after ROI draw.

### DIFF
--- a/src/View/ImageLoader.py
+++ b/src/View/ImageLoader.py
@@ -121,6 +121,7 @@ class ImageLoader(QObject):
                 # Add DVH values to PatientDictContainer
                 patient_dict_container.set("raw_dvh", raw_dvh)
                 patient_dict_container.set("dvh_x_y", dvh_x_y)
+                patient_dict_container.set("dvh_outdated", False)
 
                 return True
             else:

--- a/src/View/mainpage/DVHTab.py
+++ b/src/View/mainpage/DVHTab.py
@@ -26,7 +26,6 @@ class DVHTab(QtWidgets.QWidget):
         self.plot = None
 
         self.selected_rois = self.patient_dict_container.get("selected_rois")
-        self.roi_color = self.patient_dict_container.get("roi_color_dict")
 
         self.dvh_tab_layout = QtWidgets.QVBoxLayout()
 
@@ -91,7 +90,7 @@ class DVHTab(QtWidgets.QWidget):
 
 
                 # Color of the line is the same as the color shown in the left column of the window
-                color = self.roi_color[roi]
+                color = self.patient_dict_container.get("roi_color_dict")[roi]
                 color_R = color.red() / 255
                 color_G = color.green() / 255
                 color_B = color.blue() / 255

--- a/src/View/mainpage/DVHTab.py
+++ b/src/View/mainpage/DVHTab.py
@@ -3,10 +3,11 @@ import platform
 import threading
 
 import matplotlib.pylab as plt
-from PyQt5 import QtWidgets, QtCore
+from PyQt5 import QtWidgets, QtCore, QtGui
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from pandas import np
 
+from src.Controller.PathHandler import resource_path
 from src.Model import ImageLoading
 from src.Model.CalculateDVHs import dvh2csv
 from src.Model.PatientDictContainer import PatientDictContainer
@@ -158,6 +159,10 @@ class DVHTab(QtWidgets.QWidget):
             # Clear the current layout
             self.clear_layout()
 
+            # If the DVH has become outdated, show the user an indicator advising them such.
+            if self.patient_dict_container.get("dvh_outdated"):
+                self.display_outdated_indicator()
+
             # Re-draw the plot and add to layout
             self.init_layout_dvh()
 
@@ -173,6 +178,26 @@ class DVHTab(QtWidgets.QWidget):
         save_reply = QtWidgets.QMessageBox.information(self, "Message",
                                                       "The DVH Data was saved successfully in your directory!",
                                                       QtWidgets.QMessageBox.Ok)
+
+    def display_outdated_indicator(self):
+        self.modified_indicator_widget = QtWidgets.QWidget()
+        self.modified_indicator_widget.setContentsMargins(8, 5, 8, 5)
+        #self.modified_indicator_widget.setFixedHeight(35)
+        modified_indicator_layout = QtWidgets.QHBoxLayout()
+        modified_indicator_layout.setAlignment(QtCore.Qt.AlignLeft)
+
+        modified_indicator_icon = QtWidgets.QLabel()
+        modified_indicator_icon.setPixmap(QtGui.QPixmap(resource_path("src/res/images/btn-icons/alert_icon.png")))
+        modified_indicator_layout.addWidget(modified_indicator_icon)
+
+        modified_indicator_text = QtWidgets.QLabel("Contours have been modified since DVH calculation. Some DVHs may "
+                                                   "now be out of date.")
+        modified_indicator_text.setStyleSheet("color: red")
+        modified_indicator_layout.addWidget(modified_indicator_text)
+
+        self.modified_indicator_widget.setLayout(modified_indicator_layout)
+
+        self.dvh_tab_layout.addWidget(self.modified_indicator_widget, QtCore.Qt.AlignTop)
 
 
 class CalculateDVHProgressWindow(QtWidgets.QDialog):

--- a/src/View/mainpage/StructureTab.py
+++ b/src/View/mainpage/StructureTab.py
@@ -211,6 +211,9 @@ class StructureTab(QtWidgets.QWidget):
             self.patient_dict_container.set("dict_dicom_tree_rtss", dicom_tree_rtss.dict)
             self.color_dict = self.init_color_roi()
             self.patient_dict_container.set("roi_color_dict", self.color_dict)
+            if self.patient_dict_container.has_attribute("raw_dvh"):
+                # DVH will be outdated once changes to it are made, and recalculation will be required.
+                self.patient_dict_container.set("dvh_outdated", True)
 
         if self.patient_dict_container.has_modality("raw_dvh"):
             # Rename structures in DVH list


### PR DESCRIPTION
When adding a contour to an existing ROI, or creating a new region entirely,the DVH graph will not reflect this changes. Until the functionality to re-calculate the DVH is implemented, the user will for the time being be informed that the modified DVHs are not up to date with the calculation.