### PR TITLE
Improvements to multi-threading Worker class

### DIFF
--- a/src/Model/ImageLoading.py
+++ b/src/Model/ImageLoading.py
@@ -272,8 +272,7 @@ def get_thickness_dict(dataset_rtss, read_data_dict):
     return dict_thickness
 
 
-def calc_dvhs(dataset_rtss, dataset_rtdose, rois, dict_thickness, interrupt_flag, dose_limit=None,
-              progress_callback=None):
+def calc_dvhs(dataset_rtss, dataset_rtdose, rois, dict_thickness, interrupt_flag, dose_limit=None):
     """
     :param dataset_rtss: RTSTRUCT DICOM dataset object.
     :param dataset_rtdose: RTDOSE DICOM dataset object.
@@ -281,8 +280,6 @@ def calc_dvhs(dataset_rtss, dataset_rtdose, rois, dict_thickness, interrupt_flag
     :param dict_thickness: Dictionary where the keys are ROI numbers and the values are thicknesses of the ROI.
     :param interrupt_flag: A threading.Event() object that tells the function to stop calculation.
     :param dose_limit: Limit of dose for DVH calculation.
-    :param progress_callback: As this class is called by the multi-threading Worker class, it requires this parameter.
-    It is currently unused as no progress is reported to the calling class.
     :return: Dictionary of all the DVHs of all the ROIs of the patient.
     """
     dict_dvh = {}
@@ -307,7 +304,7 @@ def calc_dvh_worker(rtss, dose, roi, queue, thickness, dose_limit=None):
     queue.put(dvh)
 
 
-def multi_calc_dvh(dataset_rtss, dataset_rtdose, rois, dict_thickness, dose_limit=None, progress_callback=None):
+def multi_calc_dvh(dataset_rtss, dataset_rtdose, rois, dict_thickness, dose_limit=None):
     """
     Multiprocessing variant of calc_dvh for fork-based platforms.
     """

--- a/src/Model/Worker.py
+++ b/src/Model/Worker.py
@@ -33,7 +33,8 @@ class Worker(QRunnable):
         self.kwargs = kwargs
         self.signals = WorkerSignals()
 
-        self.kwargs['progress_callback'] = self.signals.progress
+        if 'progress_callback' in self.kwargs and self.kwargs['progress_callback'] is True:
+            self.kwargs['progress_callback'] = self.signals.progress
 
     @pyqtSlot()
     def run(self):

--- a/src/Model/Worker.py
+++ b/src/Model/Worker.py
@@ -14,6 +14,8 @@ class WorkerSignals(QObject):
 class Worker(QRunnable):
     """
     Multi-threading worker class that is executed by a QThreadPool.
+    The purpose of this class is to provide a simple way of executing any function on a separate thread, which proves
+    especially useful in a GUI project when a long calculation needs to run in a separate thread to the GUI thread.
     Example usage:
     calcpi_worker = Worker(calculate_pi, 500)   # Calculates pi to 500 decimal places
     calcpi_worker.signals.result.connect(display_result)
@@ -32,6 +34,22 @@ class Worker(QRunnable):
         self.args = args
         self.kwargs = kwargs
         self.signals = WorkerSignals()
+
+        # When the constructor for this class is called with a keyword argument 'progress_callback' set to True, this
+        # will allow the worker's progress signal to be connected to. However, this means that the function being called
+        # into the new thread will require a progress_callback parameter (which will, within the function being called,
+        # be a reference to the worker's progress signal). Within the called function, the progress_callback parameter
+        # can be emitted to.
+        # Below is an example of how to utilize this aspect of the Worker class.
+
+        # Creating a worker and connecting to it's callback:
+        #   worker = Worker(slow_calc_fn, list_of_inputs, progress_callback=True)
+        #   worker.signals.progress.connect(self.update_progress_bar)
+
+        # Defining the function to use and emitting signals to the callback
+        #   def slow_calc_fn(list_of_inputs, progress_callback):
+        #       progress = do_part_of_calc(...)
+        #       progress_callback.emit(progress)
 
         if 'progress_callback' in self.kwargs and self.kwargs['progress_callback'] is True:
             self.kwargs['progress_callback'] = self.signals.progress

--- a/src/View/OpenPatientWindow.py
+++ b/src/View/OpenPatientWindow.py
@@ -208,7 +208,8 @@ class UIOpenPatientWindow(object):
             self.interrupt_flag.clear()
 
             # Then, create a new thread that will load the selected folder
-            worker = Worker(DICOMDirectorySearch.get_dicom_structure, self.filepath, self.interrupt_flag)
+            worker = Worker(DICOMDirectorySearch.get_dicom_structure, self.filepath,
+                            self.interrupt_flag, progress_callback=True)
             worker.signals.result.connect(self.on_search_complete)
             worker.signals.progress.connect(self.search_progress)
 

--- a/src/View/ProgressWindow.py
+++ b/src/View/ProgressWindow.py
@@ -39,7 +39,7 @@ class ProgressWindow(QDialog):
         image_loader = ImageLoader(selected_files, self)
         image_loader.signal_request_calc_dvh.connect(self.prompt_calc_dvh)
 
-        worker = Worker(image_loader.load, self.interrupt_flag)
+        worker = Worker(image_loader.load, self.interrupt_flag, progress_callback=True)
         worker.signals.result.connect(self.on_finish)
         worker.signals.error.connect(self.on_error)
         worker.signals.progress.connect(self.update_progress)


### PR DESCRIPTION
R#1020
The Worker class has been used as a portable way of deploying and running any function in a new PyQt thread utilizing the Qt's QThreadPool and QRunnable classes, and connecting to the thread's progress/results/errors as PyQt signals.

In the previous implementation of the Worker class, any function called by the Worker class would require the called function to have a `progress_callback` parameter, representing the progress signal of the Worker class. This change makes it so that any function can be run with or without the parameter. If the Worker instance wants to emit a progress signal, it can do so by doing the following:
* In the instantiation of the worker class, set the keyword argument `progress_callback=True`. For example:
`worker = Worker(slow_calc_fn, list_of_inputs, progress_callback=True)`
* Add the parameter `progress_callback` to the declaration of the function being called, and then emit progress changes to the callback argument. For example:
```
def slow_calc_fn(list_of_inputs, progress_callback):
    progress = do_part_of_calc(...)
    progress_callback.emit(progress)
```
* In the scope of the new Worker class instance, connect to the instance's progress signal via:
`worker.signals.progress.connect(self.update_progress_bar)`

This is all explained within the Worker class' declaration in the new version. This merge also improves upon the documentation within the class, providing more specific details on how the class is used/how it works.