### PR TITLE
Improved feedback when modifying RTSTRUCT

### DIFF
--- a/src/Model/ROI.py
+++ b/src/Model/ROI.py
@@ -31,9 +31,12 @@ def delete_list_of_rois(rtss, rois_to_delete):
     Call the delete_roi function for each ROI in the given list.
     :param rtss: Dataset of RTSS.
     :param rois_to_delete: List of ROI names.
+    :return: Updated RTSS with deleted ROIs.
     """
     for item in rois_to_delete:
-        delete_roi(rtss, item)
+        rtss = delete_roi(rtss, item)
+
+    return rtss
 
 
 def delete_roi(rtss, roi_name):

--- a/src/Model/ROI.py
+++ b/src/Model/ROI.py
@@ -26,6 +26,16 @@ def rename_roi(rtss, roi_id, new_name):
     return rtss
 
 
+def delete_list_of_rois(rtss, rois_to_delete):
+    """
+    Call the delete_roi function for each ROI in the given list.
+    :param rtss: Dataset of RTSS.
+    :param rois_to_delete: List of ROI names.
+    """
+    for item in rois_to_delete:
+        delete_roi(rtss, item)
+
+
 def delete_roi(rtss, roi_name):
     """
     Delete ROI by name

--- a/src/View/mainpage/DeleteROIWindow.py
+++ b/src/View/mainpage/DeleteROIWindow.py
@@ -307,11 +307,15 @@ class UIDeleteROIWindow():
                                                       'Would you like to continue?',
                                                       QMessageBox.Yes | QMessageBox.No)
         if confirmation_dialog == QMessageBox.Yes:
-            for item in self.regions_of_interest_to_delete:
-                new_dataset = ROI.delete_roi(self.dataset_rtss, item)
+            progress_window = DeleteROIProgressWindow(self, QtCore.Qt.WindowTitleHint)
+            progress_window.signal_roi_deleted.connect(self.on_rois_deleted)
+            progress_window.start_deleting(self.dataset_rtss, self.regions_of_interest_to_delete)
+            progress_window.show()
 
-            self.deleting_rois_structure_tuple.emit((new_dataset, {"delete": self.regions_of_interest_to_delete}))
-            self.close()
+    def on_rois_deleted(self, new_rtss):
+        self.deleting_rois_structure_tuple.emit((new_rtss, {"delete": self.regions_of_interest_to_delete}))
+        QMessageBox.about(self, "Saved", "Regions of interest successfully deleted!")
+        self.close()
 
 
 class DeleteROIProgressWindow(QtWidgets.QDialog):

--- a/src/View/mainpage/DrawROIWindow.py
+++ b/src/View/mainpage/DrawROIWindow.py
@@ -584,12 +584,15 @@ class UIDrawROIWindow:
             # to be converted to a concave hull.
             pixel_hull = self.calculate_concave_hull_of_points()
             if pixel_hull is not None:
-                hull = self.convert_hull_to_rcs(pixel_hull)
+                hull = self.convert_hull_to_rcs(pixel_hull)  # Convert the polygon's pixel points to RCS locations.
+                # The list of points will need to be converted into a single-dimensional array, as RTSTRUCT contour
+                # data is stored in such a way. i.e. [x, y, z, x, y, z, x, y, z, ..., ...]
                 single_array = []
                 for sublist in hull:
                     for item in sublist:
                         single_array.append(item)
-                # new_rtss = ROI.create_roi(self.dataset_rtss, self.ROI_name, single_array, self.ds)
+
+                # Create a popup window that modifies the RTSTRUCT and tells the user that processing is happening.
                 progress_window = SaveROIProgressWindow(self, QtCore.Qt.WindowTitleHint)
                 progress_window.signal_roi_saved.connect(self.roi_saved)
                 progress_window.start_saving(self.dataset_rtss, self.ROI_name, single_array, self.ds)
@@ -690,8 +693,12 @@ class UIDrawROIWindow:
 
 
 class SaveROIProgressWindow(QtWidgets.QDialog):
+    """
+    This class displays a window that advises the user that the RTSTRUCT is being modified, and then creates a new
+    thread where the new RTSTRUCT is modified.
+    """
 
-    signal_roi_saved = QtCore.pyqtSignal(pydicom.Dataset)
+    signal_roi_saved = QtCore.pyqtSignal(pydicom.Dataset)   # Emits the new dataset
 
     def __init__(self, *args, **kwargs):
         super(SaveROIProgressWindow, self).__init__(*args, **kwargs)
@@ -705,11 +712,22 @@ class SaveROIProgressWindow(QtWidgets.QDialog):
         self.threadpool = QtCore.QThreadPool()
 
     def start_saving(self, dataset_rtss, roi_name, single_array, ds):
+        """
+        Creates a thread that generates the new dataset object.
+        :param dataset_rtss: dataset of RTSS
+        :param roi_name: ROIName
+        :param single_array: Coordinates of pixels for new ROI
+        :param ds: Data Set of selected DICOM image file
+        """
         worker = Worker(ROI.create_roi, dataset_rtss, roi_name, single_array, ds)
         worker.signals.result.connect(self.roi_saved)
         self.threadpool.start(worker)
 
     def roi_saved(self, result):
+        """
+        This method is called when the second thread completes generation of the new dataset object.
+        :param result: The resulting dataset from the ROI.create_roi function.
+        """
         self.signal_roi_saved.emit(result)
         self.close()
 

--- a/src/View/mainpage/DrawROIWindow.py
+++ b/src/View/mainpage/DrawROIWindow.py
@@ -589,10 +589,7 @@ class UIDrawROIWindow:
                         single_array.append(item)
                 new_rtss = ROI.create_roi(self.dataset_rtss, self.ROI_name, single_array, self.ds)
                 self.signal_roi_drawn.emit((new_rtss, {"draw": self.ROI_name}))
-                QMessageBox.about(self.draw_roi_window_instance, "Warning",
-                                  "This feature is still in development. The ROI will appear in your structures tab,"
-                                                                        " but may demonstrate some technical issues "
-                                                                        "when performing tasks.")
+                QMessageBox.about(self.draw_roi_window_instance, "Saved", "New contour successfully created!")
                 self.close()
             else:
                 QMessageBox.about(self.draw_roi_window_instance, "Multipolygon detected",

--- a/src/View/mainpage/RenameROIWindow.py
+++ b/src/View/mainpage/RenameROIWindow.py
@@ -1,9 +1,13 @@
-from PyQt5 import QtGui
+import pydicom
+from PyQt5 import QtGui, QtWidgets, QtCore
 from PyQt5.QtWidgets import QDialog, QLabel, QLineEdit, QVBoxLayout, QWidget, QHBoxLayout, QPushButton, QListWidget
 
 from src.Model import ROI
 from src.Controller.PathHandler import resource_path
 import platform
+
+from src.Model.Worker import Worker
+
 
 class RenameROIWindow(QDialog):
 
@@ -103,11 +107,6 @@ class RenameROIWindow(QDialog):
     def on_rename_clicked(self):
         new_name = self.input_field.text()
         new_dataset = ROI.rename_roi(self.rtss, self.roi_id, new_name)
-        # TODO rather than save this so a file straight away, the dataset is sent as part of the signal further
-        # up towards the main page and then 'replaces' the current rtss. at some point the user is given the
-        # option of saving this new rtss file. when the rtss file is replaced it also recalculates the rois and
-        # reload the structure widget's structures.
-        print()
         self.rename_signal.emit((new_dataset, {"rename": [self.roi_name, new_name]}))
         self.close()
 
@@ -116,3 +115,42 @@ class RenameROIWindow(QDialog):
         # Excluding headers from being clicked.
         if not str(clicked_ROI.text()).startswith("------------Standard"):
             self.input_field.setText(str(clicked_ROI.text()))
+
+
+class RenameROIProgressWindow(QtWidgets.QDialog):
+    """
+    This class displays a window that advises the user that the RTSTRUCT is being modified, and then creates a new
+    thread where the new RTSTRUCT is modified.
+    """
+
+    signal_roi_renamed = QtCore.pyqtSignal(pydicom.Dataset)   # Emits the new dataset
+
+    def __init__(self, *args, **kwargs):
+        super(RenameROIProgressWindow, self).__init__(*args, **kwargs)
+        layout = QtWidgets.QVBoxLayout()
+        text = QtWidgets.QLabel("Renaming ROIs...")
+        layout.addWidget(text)
+        self.setWindowTitle("Please wait...")
+        self.setFixedWidth(150)
+        self.setLayout(layout)
+
+        self.threadpool = QtCore.QThreadPool()
+
+    def start_renaming(self, dataset_rtss, roi_id, new_name):
+        """
+        Creates a thread that generates the new dataset object.
+        :param dataset_rtss: Dataset of RTSS.
+        :param roi_id: ID of the ROI to be renamed.
+        :param new_name: The name the ROI will be changed to.
+        """
+        worker = Worker(ROI.rename_roi, dataset_rtss, roi_id, new_name)
+        worker.signals.result.connect(self.roi_deleted)
+        self.threadpool.start(worker)
+
+    def roi_renamed(self, result):
+        """
+        This method is called when the second thread completes generation of the new dataset object.
+        :param result: The resulting dataset from the ROI.rename_roi function.
+        """
+        self.signal_roi_renamed.emit(result)
+        self.close()


### PR DESCRIPTION
R#1021
These changes show the user visual feedback when Drawing, Deleting, or Renaming ROIs. Previously, the window would freeze while the RTSTRUCT would be updated, however that is unideal and can lead to users believing the program is no longer working. Now, a small window will pop up advising the user that some process is being run in the background and to wait for its completion.