### PR TITLE
Rejig requirements

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -17,8 +17,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install -r pre-requirements.txt
         pip install -r requirements.txt
-        pip install --no-deps -r requirements-without-deps.txt
         pip install pytest-xvfb pytest-qt
     - name: Lint with flake8
       run: |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 <p align="center"><img src="src/res/images/onkodicom_main_banner.png?raw=true" alt="main-icon-onko-dicom" width="250"></p>
 
 # Onko
-OnkoDICOM was created with Radiation Oncologists to allow Radiation Oncologists to do research on DICOM standard image sets (DICOM-RT, CT, MRI, PET) using open source technologies, such as pydicom, dicompyler-core, Pyqt5, PIL, and matplotlib. OnkoDICOM is cross platform, open source software, and welcomes contributions from the wider community via GitHub https://github.com/didymo/OnkoDICOM.
+OnkoDICOM was created with Radiation Oncologists to allow Radiation Oncologists to do research on DICOM standard image
+sets (DICOM-RT, CT, MRI, PET) using open source technologies, such as pydicom, dicompyler-core, Pyqt5, PIL, and
+matplotlib. OnkoDICOM is cross platform, open source software, and welcomes contributions from the wider community via
+GitHub https://github.com/didymo/OnkoDICOM.
 
 
 OnkoDICOM was inspired by the [dicompyler project](https://github.com/bastula/dicompyler).
@@ -22,31 +25,36 @@ installed by running this command in the terminal.
 
 `sudo apt install virtualenv git python3-dev gcc`
 
+If you are installing onto Windows, you will need to have installed Visual Studio Build Tools, and a 64-bit version of
+Python.
+
 Clone the Onko repository
 
 `git clone https://github.com/didymo/OnkoDICOM.git`
 
 Enter the directory and create a virtual environment with a name of
-your choice, in this case it's envOnkoDICOM.
+your choice, in this case it's venv.
 
 `cd OnkoDICOM`
 
 `virtualenv --python=python3 venv`
 
+Note that when cloning into a PyCharm workspace, it is recommended to create a virtual environment from the terminal
+_outside_ of PyCharm, as PyCharm's built-in virtual environment creation often leads to issues with the pip version.
+
 Activate the virtual environment
 
 `source venv/bin/activate`
 
-OR
+OR for Windows
 
 `venv/Scripts/activate.bat`
 
 Install the requirements
 
+`pip install -r pre-requirements.txt`
+
 `pip install -r requirements.txt`
-
-`pip install --no-deps -r requirements-without-deps.txt`
-
 
 You can execute Onko by running
 

--- a/pre-requirements.txt
+++ b/pre-requirements.txt
@@ -1,0 +1,2 @@
+cython
+numpy~=1.19

--- a/requirements-without-deps.txt
+++ b/requirements-without-deps.txt
@@ -1,2 +1,0 @@
-pymedphys>=0.35
-git+https://github.com/Radiomics/pyradiomics.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,5 @@
 alphashape
-numpy~=1.19
 pandas
-cython
-cpython
 scikit-build
 scipy
 dicompyler-core
@@ -15,3 +12,5 @@ matplotlib==3.2.0
 PyWavelets==0.5.2
 dataclasses==0.7;python_version=="3.6.*"
 networkx
+pymedphys>=0.35
+git+https://github.com/Radiomics/pyradiomics.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ dataclasses==0.7;python_version=="3.6.*"
 networkx
 pymedphys>=0.35
 git+https://github.com/Radiomics/pyradiomics.git
+pytest


### PR DESCRIPTION
Due to issues with the way pip works, despite Cython being listed as a dependency for PyWavelets it does not install automatically. There is a similar issue with numpy. There was also an issue being caused by PyRadiomics not being installed without dependencies. For these reasons, the requirements have been restructured to have pre-requirements. These will be installed, and then the regular requirements will be installed. The GitHub Action for testing has been updated to accommodate this change.

Additionally, the README has been updated to provided better and more up-to-date information.