### PR TITLE
Fix inappropriate dependence on first contour sequence

### DIFF
--- a/src/Model/ImageLoading.py
+++ b/src/Model/ImageLoading.py
@@ -230,9 +230,13 @@ def get_thickness_dict(dataset_rtss, read_data_dict):
     # Value of each key is the SOPInstanceUID of the CT slice the contour is positioned on.
     single_contour_rois = {}
     for contour in dataset_rtss.ROIContourSequence:
-        if len(contour.ContourSequence) == 1:
-            single_contour_rois[contour.ReferencedROINumber] = \
-                contour.ContourSequence[0].ContourImageSequence[0].ReferencedSOPInstanceUID
+        try:
+            if len(contour.ContourSequence) == 1:        
+                single_contour_rois[contour.ReferencedROINumber] = \
+                    contour.ContourSequence[0].ContourImageSequence[0].ReferencedSOPInstanceUID
+            
+        except AttributeError:
+            pass
 
     dict_thickness = {}
     for roi_number, sop_instance_uid in single_contour_rois.items():


### PR DESCRIPTION
Sample data had Points (of interest) as the first few ROIs, and those did not have a contour sequence (so no contour image sequence contained within).
Further work to address checking that the data is "suitable for use" is warranted.
The POIs will show in OnkoDICOM, but if the user selects the checkbox, a warning message will appear in the terminal.
I did not test through to "able to produce radiomics", so complete end to end testing with such sample data is needed. 