### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,6 @@ matplotlib==3.2.0
 PyWavelets==0.5.2
 dataclasses==0.7;python_version=="3.6.*"
 networkx
-pymedphys>=0.35
+pymedphys>=0.35,<=0.37.1
 git+https://github.com/Radiomics/pyradiomics.git
 pytest


### PR DESCRIPTION
pin pymedphys to 0.37.1 or less because the API to pseudonymisation is going to get disabled (there is an attack vector to one of the DICOM elements and the owner of PyMedPhys would prefer to disable access to pseudonymisation until that gets resolved).