### PR TITLE
Feature: Optimisation for Directory Search function in Open Patient Window

### DIFF
--- a/src/Model/DICOMDirectorySearch.py
+++ b/src/Model/DICOMDirectorySearch.py
@@ -21,7 +21,7 @@ def get_dicom_structure(path, interrupt_flag, progress_callback):
 
     files_searched = 0
 
-    no_patient_id = 1
+    files_with_no_patient_id = 1
 
     for root, dirs, files in os.walk(path, topdown=True):
         files = [f for f in files if not f[0] == '.']
@@ -50,8 +50,8 @@ def get_dicom_structure(path, interrupt_flag, progress_callback):
                 if 'PatientID' in dicom_file:
                     patient_id = dicom_file.PatientID
                 else:
-                    patient_id = "no_id_" + str(no_patient_id)
-                    no_patient_id += 1
+                    patient_id = "no_id_" + str(files_with_no_patient_id)
+                    files_with_no_patient_id += 1
 
                 if "SOPInstanceUID" in dicom_file and "SOPClassUID" in dicom_file and "Modality" in dicom_file:
                     new_image = Image(file_path, dicom_file.SOPInstanceUID, dicom_file.SOPClassUID, dicom_file.Modality)

--- a/src/Model/DICOMStructure.py
+++ b/src/Model/DICOMStructure.py
@@ -53,11 +53,7 @@ class DICOMStructure:
         """
         :return: A list of QTreeWidgetItems based on the DICOMStructure object.
         """
-        new_items_list = []
-        for patient_id, patient in self.patients.items():
-            new_items_list.append(patient.get_widget_item())
-
-        return new_items_list
+        return [patient.get_widget_item() for patient_id, patient in self.patients.items()]
 
 
 class Patient:

--- a/src/Model/DICOMStructure.py
+++ b/src/Model/DICOMStructure.py
@@ -12,13 +12,13 @@ class DICOMStructure:
 
     def __init__(self):
         """
-        patients: A list of Patient objects.
+        patients: A dictionary of Patient objects.
         """
         self.patients = {}
 
     def add_patient(self, patient):
         """
-        Add a Patient object to the list of patients.
+        Add a Patient object to the dictionary of patients.
         :param patient: A Patient object.
         """
         self.patients[patient.patient_id] = patient
@@ -64,7 +64,7 @@ class Patient:
 
     def __init__(self, patient_id, patient_name):
         """
-        studies: A list of Study objects.
+        studies: A dictionary of Study objects.
         :param patient_id: PatientID in DICOM standard.
         """
         self.patient_id = patient_id
@@ -73,7 +73,7 @@ class Patient:
 
     def add_study(self, study):
         """
-        Adds a Study object to the patient's list of studies.
+        Adds a Study object to the patient's dictionary of studies.
         :param study: A Study object.
         """
         self.studies[study.study_uid] = study
@@ -128,7 +128,7 @@ class Study:
 
     def __init__(self, study_uid):
         """
-        series: A list of Series objects.
+        series: A dictionary of Series objects.
         :param study_uid: StudyInstanceUID in DICOM standard.
         """
         self.study_uid = study_uid
@@ -137,7 +137,7 @@ class Study:
 
     def add_series(self, series):
         """
-        Adds a Series object to the patient's list of series.
+        Adds a Series object to the patient's dictionary of series.
         :param series: A Series object.
         """
         self.series[series.series_uid] = series
@@ -209,7 +209,7 @@ class Series:
 
     def __init__(self, series_uid):
         """
-        images: A list of Image objects.
+        images: A dictionary of Image objects.
         :param series_uid: SeriesInstanceUID in DICOM standard.
         """
         self.series_uid = series_uid
@@ -218,7 +218,7 @@ class Series:
 
     def add_image(self, image):
         """
-        Adds an Image object to the patient's list of images.
+        Adds an Image object to the patient's dictionary of images.
         :param image:  An Image object.
         """
         self.images[image.image_uid] = image

--- a/src/Model/DICOMStructure.py
+++ b/src/Model/DICOMStructure.py
@@ -76,22 +76,22 @@ class Patient:
         Adds a Study object to the patient's list of studies.
         :param study: A Study object.
         """
-        self.studies[study.study_id] = study
+        self.studies[study.study_uid] = study
 
-    def has_study(self, study_id):
+    def has_study(self, study_uid):
         """
-        :param study_id: StudyInstanceUID to check.
-        :return: True if studies contains study_id
+        :param study_uid: StudyInstanceUID to check.
+        :return: True if studies contains study_uid
         """
-        return study_id in self.studies
+        return study_uid in self.studies
 
-    def get_study(self, study_id):
+    def get_study(self, study_uid):
         """
-        :param study_id: StudyID to check.
+        :param study_uid: StudyID to check.
         :return: Study object if study found.
         """
-        if self.has_study(study_id):
-            return self.studies[study_id]
+        if self.has_study(study_uid):
+            return self.studies[study_uid]
         return None
 
     def get_files(self):
@@ -99,7 +99,7 @@ class Patient:
         :return: List of all filepaths in all images below this item in the hierarchy.
         """
         filepaths = []
-        for study_id, study in self.studies.items():
+        for study_uid, study in self.studies.items():
             filepaths += (study.get_files())
 
         return filepaths
@@ -118,7 +118,7 @@ class Patient:
         widget_item.setFlags(widget_item.flags() | Qt.ItemIsAutoTristate | Qt.ItemIsUserCheckable)
 
         # Add all children of this object as children of the widget item.
-        for study_id, study in self.studies.items():
+        for study_uid, study in self.studies.items():
             widget_item.addChild(study.get_widget_item())
 
         return widget_item
@@ -126,12 +126,12 @@ class Patient:
 
 class Study:
 
-    def __init__(self, study_id):
+    def __init__(self, study_uid):
         """
         series: A list of Series objects.
-        :param study_id: StudyInstanceUID in DICOM standard.
+        :param study_uid: StudyInstanceUID in DICOM standard.
         """
-        self.study_id = study_id
+        self.study_uid = study_uid
         self.study_description = None
         self.series = {}
 
@@ -140,22 +140,22 @@ class Study:
         Adds a Series object to the patient's list of series.
         :param series: A Series object.
         """
-        self.series[series.series_id] = series
+        self.series[series.series_uid] = series
 
-    def has_series(self, series_id):
+    def has_series(self, series_uid):
         """
-        :param series_id: A SeriesInstanceUID to check.
-        :return: True if series contains series_id.
+        :param series_uid: A SeriesInstanceUID to check.
+        :return: True if series contains series_uid.
         """
-        return series_id in self.series
+        return series_uid in self.series
 
-    def get_series(self, series_id):
+    def get_series(self, series_uid):
         """
-        :param series_id: SeriesID to check.
+        :param series_uid: SeriesID to check.
         :return: Series object if series found.
         """
-        if self.has_series(series_id):
-            return self.series[series_id]
+        if self.has_series(series_uid):
+            return self.series[series_uid]
         return None
 
     def get_files(self):
@@ -163,7 +163,7 @@ class Study:
         :return: List of all filepaths in all images below this item in the hierarchy.
         """
         filepaths = []
-        for series_id, series in self.series.items():
+        for series_uid, series in self.series.items():
             filepaths += (series.get_files())
 
         return filepaths
@@ -184,8 +184,8 @@ class Study:
                       "1.2.840.10008.5.1.4.1.1.481.5"]      # RT Plan
 
         contained_classes = []
-        for series_id, series in self.series.items():
-            for image_id, image in series.images.items():
+        for series_uid, series in self.series.items():
+            for image_uid, image in series.images.items():
                 if image.class_id not in contained_classes:
                     contained_classes.append(image.class_id)
 
@@ -199,7 +199,7 @@ class Study:
         widget_item.setFlags(widget_item.flags() | Qt.ItemIsAutoTristate | Qt.ItemIsUserCheckable)
 
         # Add all children of this object as children of the widget item.
-        for series_id, series in self.series.items():
+        for series_uid, series in self.series.items():
             widget_item.addChild(series.get_widget_item())
 
         return widget_item
@@ -207,12 +207,12 @@ class Study:
 
 class Series:
 
-    def __init__(self, series_id):
+    def __init__(self, series_uid):
         """
         images: A list of Image objects.
-        :param series_id: SeriesInstanceUID in DICOM standard.
+        :param series_uid: SeriesInstanceUID in DICOM standard.
         """
-        self.series_id = series_id
+        self.series_uid = series_uid
         self.series_description = None
         self.images = {}
 
@@ -221,22 +221,22 @@ class Series:
         Adds an Image object to the patient's list of images.
         :param image:  An Image object.
         """
-        self.images[image.image_id] = image
+        self.images[image.image_uid] = image
 
-    def has_image(self, image_id):
+    def has_image(self, image_uid):
         """
-        :param image_id: A SOPInstanceUID to check.
-        :return: True if images contains image_id.
+        :param image_uid: A SOPInstanceUID to check.
+        :return: True if images contains image_uid.
         """
-        return image_id in self.images
+        return image_uid in self.images
 
-    def get_image(self, image_id):
+    def get_image(self, image_uid):
         """
-        :param image_id: ImageID to check
+        :param image_uid: ImageID to check
         :return: Image object if Image found.
         """
-        if self.get_image(image_id):
-            return self.images[image_id]
+        if self.get_image(image_uid):
+            return self.images[image_uid]
         return None
 
     def get_files(self):
@@ -244,7 +244,7 @@ class Series:
         :return: List of all filepaths in all images below this item in the hierarchy.
         """
         filepaths = []
-        for image_id, image in self.images.items():
+        for image_uid, image in self.images.items():
             filepaths += [image.path]
 
         return filepaths
@@ -260,7 +260,7 @@ class Series:
         :return: List of string or single string containing modalities of all images in the series.
         """
         series_types = []
-        for image_id, image in self.images.items():
+        for image_uid, image in self.images.items():
             if image.modality not in series_types:
                 series_types.append(image.modality)
         return series_types if len(series_types) > 1 else series_types[0]
@@ -277,14 +277,14 @@ class Series:
 
 class Image:
 
-    def __init__(self, path, image_id, class_id, modality):
+    def __init__(self, path, image_uid, class_id, modality):
         """
-        image_id: SOPInstanceUID in DICOM standard.
+        image_uid: SOPInstanceUID in DICOM standard.
         :param dicom_file: A PyDicom dataset.
         :param path: Path of the DICOM file.
         """
         self.path = path
-        self.image_id = image_id
+        self.image_uid = image_uid
         self.class_id = class_id
         self.modality = modality
 
@@ -292,4 +292,4 @@ class Image:
         """
         :return: Information about the object as a string
         """
-        return "Image: %s | Path: %s" % (self.image_id, self.path)
+        return "Image: %s | Path: %s" % (self.image_uid, self.path)


### PR DESCRIPTION
The current Directory Search function in the open patient window is slow and not fault-tolerant. This PR can improve the search function by:
- Remove counting "total files" since it walks through all files in the directory to get the total number of files which doubles the running time
- Change DICOMStructure arrays to hashmaps to get O(1) search instead of O(n)
- Ignore hidden directories to avoid reading configuration and system files which can cause the program to crash