### PR TITLE
Red error text in QTreeView (OpenPatientWindow)

### DIFF
--- a/res/stylesheet-win-linux.qss
+++ b/res/stylesheet-win-linux.qss
@@ -184,6 +184,9 @@ QLineEdit:focus {
 QTreeView#OpenPatientWindowPatientsTree {
     margin: 0 12px 4px 12px;
 }
+QHeaderView {
+    color: red;
+}
 QTreeView::item {
     color: #000000;
     min-height: 36px;

--- a/res/stylesheet.qss
+++ b/res/stylesheet.qss
@@ -148,6 +148,9 @@ QLineEdit:focus {
 QTreeView#OpenPatientWindowPatientsTree {
     margin: 0 12px 4px 12px;
 }
+QHeaderView {
+    color: red;
+}
 QTreeView::item {
     color: #000000;
     min-height: 36px;


### PR DESCRIPTION
Change the color of the error text when missing DICOM files from black to red so that the error is distinguished from the other text. 