### PR TITLE
Renamed slots and method names

### DIFF
--- a/src/Controller/AddOnOptionsController.py
+++ b/src/Controller/AddOnOptionsController.py
@@ -97,7 +97,7 @@ class AddOnOptions(QtWidgets.QMainWindow, UIAddOnOptions):
         self.import_data(data)
         self.treeList.expandAll()
         # fill the corresponding tables with the corresponding data from the csv files
-        self.fillTables()
+        self.fill_tables()
         self.treeList.setEditTriggers(
             QtWidgets.QTreeView.NoEditTriggers
         )  # make the tree entries not editable
@@ -398,12 +398,12 @@ class AddOnOptions(QtWidgets.QMainWindow, UIAddOnOptions):
     #                                                                                                                 #
     ###################################################################################################################
 
-    def fillTables(self):
+    def fill_tables(self):
         # Fill the Windowing table
-        with open(resource_path("data/csv/imageWindowing.csv"), "r") as fileInput:
-            next(fileInput)
+        with open(resource_path("data/csv/imageWindowing.csv"), "r") as file_Input:
+            next(file_Input)
             i = 0
-            for row in fileInput:
+            for row in file_Input:
                 items = [
                     QTableWidgetItem(str(item.replace("\n", "")))
                     for item in row.split(",")
@@ -416,10 +416,10 @@ class AddOnOptions(QtWidgets.QMainWindow, UIAddOnOptions):
                 i += 1
 
         # organ names table
-        with open(resource_path("data/csv/organName.csv"), "r") as fileInput:
-            next(fileInput)
+        with open(resource_path("data/csv/organName.csv"), "r") as file_Input:
+            next(file_Input)
             i = 0
-            for row in fileInput:
+            for row in file_Input:
                 items = [
                     QTableWidgetItem(str(item.replace("\n", "")))
                     for item in row.split(",")
@@ -433,9 +433,9 @@ class AddOnOptions(QtWidgets.QMainWindow, UIAddOnOptions):
                 i += 1
 
         # volume name table
-        with open(resource_path("data/csv/volumeName.csv"), "r") as fileInput:
+        with open(resource_path("data/csv/volumeName.csv"), "r") as file_Input:
             i = 0
-            for row in fileInput:
+            for row in file_Input:
                 items = [
                     QTableWidgetItem(str(item.replace("\n", "")))
                     for item in row.split(",")
@@ -462,10 +462,10 @@ class AddOnOptions(QtWidgets.QMainWindow, UIAddOnOptions):
         #         i += 1
 
         # patient hash ID table, which is just for displaying all the patients anonymized byt the software since intallation
-        with open(resource_path("data/csv/patientHash.csv"), "r") as fileInput:
-            next(fileInput)
+        with open(resource_path("data/csv/patientHash.csv"), "r") as file_Input:
+            next(file_Input)
             i = 0
-            for row in fileInput:
+            for row in file_Input:
                 items = [
                     QTableWidgetItem(str(item.replace("\n", "")))
                     for item in row.split(",")

--- a/src/Controller/AddOnOptionsController.py
+++ b/src/Controller/AddOnOptionsController.py
@@ -400,10 +400,10 @@ class AddOnOptions(QtWidgets.QMainWindow, UIAddOnOptions):
 
     def fill_tables(self):
         # Fill the Windowing table
-        with open(resource_path("data/csv/imageWindowing.csv"), "r") as file_Input:
-            next(file_Input)
+        with open(resource_path("data/csv/imageWindowing.csv"), "r") as file_input:
+            next(file_input)
             i = 0
-            for row in file_Input:
+            for row in file_input:
                 items = [
                     QTableWidgetItem(str(item.replace("\n", "")))
                     for item in row.split(",")
@@ -416,10 +416,10 @@ class AddOnOptions(QtWidgets.QMainWindow, UIAddOnOptions):
                 i += 1
 
         # organ names table
-        with open(resource_path("data/csv/organName.csv"), "r") as file_Input:
-            next(file_Input)
+        with open(resource_path("data/csv/organName.csv"), "r") as file_input:
+            next(file_input)
             i = 0
-            for row in file_Input:
+            for row in file_input:
                 items = [
                     QTableWidgetItem(str(item.replace("\n", "")))
                     for item in row.split(",")
@@ -433,9 +433,9 @@ class AddOnOptions(QtWidgets.QMainWindow, UIAddOnOptions):
                 i += 1
 
         # volume name table
-        with open(resource_path("data/csv/volumeName.csv"), "r") as file_Input:
+        with open(resource_path("data/csv/volumeName.csv"), "r") as file_input:
             i = 0
-            for row in file_Input:
+            for row in file_input:
                 items = [
                     QTableWidgetItem(str(item.replace("\n", "")))
                     for item in row.split(",")
@@ -462,10 +462,10 @@ class AddOnOptions(QtWidgets.QMainWindow, UIAddOnOptions):
         #         i += 1
 
         # patient hash ID table, which is just for displaying all the patients anonymized byt the software since intallation
-        with open(resource_path("data/csv/patientHash.csv"), "r") as file_Input:
-            next(file_Input)
+        with open(resource_path("data/csv/patientHash.csv"), "r") as file_input:
+            next(file_input)
             i = 0
-            for row in file_Input:
+            for row in file_input:
                 items = [
                     QTableWidgetItem(str(item.replace("\n", "")))
                     for item in row.split(",")

--- a/src/Controller/AddOnOptionsController.py
+++ b/src/Controller/AddOnOptionsController.py
@@ -94,7 +94,7 @@ class AddOnOptions(QtWidgets.QMainWindow, UIAddOnOptions):
         # create a model for the tree view of options and attach the data
         self.model = QtGui.QStandardItemModel()
         self.treeList.setModel(self.model)
-        self.importData(data)
+        self.import_data(data)
         self.treeList.expandAll()
         # fill the corresponding tables with the corresponding data from the csv files
         self.fillTables()
@@ -116,15 +116,15 @@ class AddOnOptions(QtWidgets.QMainWindow, UIAddOnOptions):
         # adding the right click menus for each table
         self.table_view.setContextMenuPolicy(QtCore.Qt.ContextMenuPolicy.CustomContextMenu)
         self.table_view.customContextMenuRequested.connect(
-            self.on_customContextMenuRequested_Window
+            self.on_customContextMenuRequestedWindow
         )
         self.table_organ.setContextMenuPolicy(QtCore.Qt.ContextMenuPolicy.CustomContextMenu)
         self.table_organ.customContextMenuRequested.connect(
-            self.on_customContextMenuRequested_Organ
+            self.on_customContextMenuRequestedOrgan
         )
         self.table_volume.setContextMenuPolicy(QtCore.Qt.ContextMenuPolicy.CustomContextMenu)
         self.table_volume.customContextMenuRequested.connect(
-            self.on_customContextMenuRequested_Volume
+            self.on_customContextMenuRequestedVolume
         )
         # self.table_roi.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
         # self.table_roi.customContextMenuRequested.connect(self.on_customContextMenuRequested_Roi)
@@ -147,7 +147,7 @@ class AddOnOptions(QtWidgets.QMainWindow, UIAddOnOptions):
     ######################################################################################################
     # windowing
     @Slot(QtCore.QPoint)
-    def on_customContextMenuRequested_Window(self, pos):
+    def on_customContextMenuRequestedWindow(self, pos):
         # gets the position of the right click for the windowing table
         it = self.table_view.itemAt(pos)
         if it is None:
@@ -185,7 +185,7 @@ class AddOnOptions(QtWidgets.QMainWindow, UIAddOnOptions):
 
     # standard organ name table
     @Slot(QtCore.QPoint)
-    def on_customContextMenuRequested_Organ(self, pos):
+    def on_customContextMenuRequestedOrgan(self, pos):
         it = self.table_organ.itemAt(pos)
         if it is None:
             return
@@ -218,7 +218,7 @@ class AddOnOptions(QtWidgets.QMainWindow, UIAddOnOptions):
 
     # standard volume table
     @Slot(QtCore.QPoint)
-    def on_customContextMenuRequested_Volume(self, pos):
+    def on_customContextMenuRequestedVolume(self, pos):
         it = self.table_volume.itemAt(pos)
         if it is None:
             return
@@ -278,7 +278,7 @@ class AddOnOptions(QtWidgets.QMainWindow, UIAddOnOptions):
     #                                                                                                    #
     ######################################################################################################
 
-    def importData(self, data, root=None):
+    def import_data(self, data, root=None):
         self.model.setRowCount(0)
         if root is None:
             root = self.model.invisibleRootItem()


### PR DESCRIPTION
Changed names of slots in file AddOnOptionsController to work with PySide's slot signature to avoid the following errors received on Linux: 

qt.core.qmetaobject.connectslotsbyname: QMetaObject::connectSlotsByName: No matching signal for on_customContextMenuRequested_Window(QPoint)

qt.core.qmetaobject.connectslotsbyname: QMetaObject::connectSlotsByName: No matching signal for on_customContextMenuRequested_Organ(QPoint)

qt.core.qmetaobject.connectslotsbyname: QMetaObject::connectSlotsByName: No matching signal for on_customContextMenuRequested_Volume(QPoint) 

Also changed method names to align with the naming conventions. 
