### PR TITLE
Disable directory refresh in open patient window

### DIFF
--- a/src/Controller/AddOnOptionsController.py
+++ b/src/Controller/AddOnOptionsController.py
@@ -9,7 +9,7 @@ import webbrowser
 from collections import deque
 
 from PySide6.QtWidgets import QFileDialog, QTableWidgetItem
-from PySide6.QtCore import Slot, Signal
+from PySide6.QtCore import Slot
 
 from src.View.AddOnOptions import *
 from src.View.InputDialogs import *
@@ -24,7 +24,6 @@ from src.Controller.PathHandler import resource_path
 
 
 class AddOnOptions(QtWidgets.QMainWindow, UIAddOnOptions):
-    directory_updated = Signal(str)
 
     def __init__(self, window):  # initialization function
         super(AddOnOptions, self).__init__()
@@ -377,7 +376,6 @@ class AddOnOptions(QtWidgets.QMainWindow, UIAddOnOptions):
         try:
             new_dir = self.change_default_directory.change_default_directory_input_box.text()
             configuration.update_default_directory(new_dir)
-            self.directory_updated.emit(new_dir)
             QMessageBox.about(self, "Success", "Default directory was successfully updated")
         except SqlError:
             configuration.set_up_config_db()
@@ -571,7 +569,6 @@ class AddOptions:
     def __init__(self, window):
         self.window = window
         self.options_window = AddOnOptions(window)
-        self.options_window.directory_updated.connect(lambda new_dir: self.window.directory_updated.emit(new_dir))
 
     def show_add_on_options(self):
         self.options_window.show()

--- a/src/Controller/TopLevelController.py
+++ b/src/Controller/TopLevelController.py
@@ -52,9 +52,6 @@ class Controller:
         if not isinstance(self.main_window, MainWindow):
             self.open_patient_window = OpenPatientWindow(self.default_directory)
             self.open_patient_window.go_next_window.connect(self.show_main_window)
-        else:
-            self.open_patient_window.open_patient_directory_input_box.setText(self.default_directory)
-            self.open_patient_window.scan_directory_for_patient()
 
         self.open_patient_window.show()
 
@@ -69,7 +66,6 @@ class Controller:
             self.main_window = MainWindow()
             self.main_window.open_patient_window.connect(self.show_open_patient)
             self.main_window.run_pyradiomics.connect(self.show_pyradi_progress)
-            self.main_window.directory_updated.connect(self.update_default_directory)
 
         # Once the MainWindow has finished loading (which takes some time) close all the other open windows.
         progress_window.update_progress(("Loading complete!", 100))

--- a/src/View/mainpage/MainPage.py
+++ b/src/View/mainpage/MainPage.py
@@ -34,7 +34,6 @@ class UIMainWindow:
     itself can safely be passed into the class.
     """
     pyradi_trigger = QtCore.Signal(str, dict, str)
-    directory_updated = QtCore.Signal(str)
 
     def setup_ui(self, main_window_instance):
         self.main_window_instance = main_window_instance


### PR DESCRIPTION
The open patient window will no longer refresh the directory when the oncologist wants to open a new patient.
This is done following the comment from Dr. Andrew Miller.

> For Patient File directory; I tested this today.
When I start, there is a directory reading process to find all patients in the default file. [good]
I opened a patient, did what I must and then went to select a new patient.
The Patient File directory opened again, and the whole directory reading process occurs again. [?good practice but bad for time]
I would like to have a discussion about the usefulness of displaying the patient list as it was previously. By the end of this year, the only change in directory structure is going to be the addition of RTSTRUCT and DICOM-SR files. Other files are already ignored.
What are the ramifications of displaying the top patient list from the old directory structure immediately and running the refresh in the background? In the use case, oncologist is likely to go from one case to the next sequentially (why would you say you wanted to load a new patient and then try to load the same one?)