### PR TITLE
Bug fix: cannot open a PET (PT) scan

### DIFF
--- a/src/View/OpenPatientWindow.py
+++ b/src/View/OpenPatientWindow.py
@@ -294,7 +294,7 @@ class UIOpenPatientWindow(object):
                 self.selected_series_types.update(series_type)
 
         # Check the existence of IMAGE, RTSTRUCT and RTDOSE files
-        if len(list({'CT', 'MR', 'PET'} & self.selected_series_types)) == 0:
+        if len(list({'CT', 'MR', 'PT'} & self.selected_series_types)) == 0:
             header = "Cannot proceed without an image file."
             self.open_patient_window_confirm_button.setDisabled(True)
         elif 'RTSTRUCT' not in self.selected_series_types:
@@ -305,7 +305,7 @@ class UIOpenPatientWindow(object):
             header = ""
         self.open_patient_window_patients_tree.setHeaderLabel(header)
 
-        if len(list({'CT', 'MR', 'PET'} & self.selected_series_types)) != 0:
+        if len(list({'CT', 'MR', 'PT'} & self.selected_series_types)) != 0:
             self.open_patient_window_confirm_button.setDisabled(False)
 
     def confirm_button_clicked(self):


### PR DESCRIPTION
The wrong image type in the Open Patient Window prevents the application from opening PET scans.
In relation to issue #1565 on Onko's Redmine.