### PR TITLE
Bug#1579: zoom magnifiers not working

### DIFF
--- a/src/Controller/ActionHandler.py
+++ b/src/Controller/ActionHandler.py
@@ -73,7 +73,7 @@ class ActionHandler:
         self.action_zoom_out.setIcon(self.icon_zoom_out)
         self.action_zoom_out.setIconVisibleInMenu(True)
         self.action_zoom_out.setText("Zoom Out")
-        self.action_zoom_out.triggered.connect(self.__main_page.dicom_view.zoom_out)
+        self.action_zoom_out.triggered.connect(self.__main_page.zoom_out)
 
         # Zoom In Action
         self.icon_zoom_in = QtGui.QIcon()
@@ -86,7 +86,7 @@ class ActionHandler:
         self.action_zoom_in.setIcon(self.icon_zoom_in)
         self.action_zoom_in.setIconVisibleInMenu(True)
         self.action_zoom_in.setText("Zoom In")
-        self.action_zoom_in.triggered.connect(self.__main_page.dicom_view.zoom_in)
+        self.action_zoom_in.triggered.connect(self.__main_page.zoom_in)
 
         # Transect Action
         self.icon_transect = QtGui.QIcon()

--- a/src/View/mainpage/MainPage.py
+++ b/src/View/mainpage/MainPage.py
@@ -163,3 +163,9 @@ class UIMainWindow:
         self.dicom_view.update_view()
         if hasattr(self, 'dvh_tab'):
             self.dvh_tab.update_plot()
+
+    def zoom_in(self):
+        self.dicom_view.zoom_in()
+
+    def zoom_out(self):
+        self.dicom_view.zoom_out()

--- a/src/View/mainpage/StructureWidget.py
+++ b/src/View/mainpage/StructureWidget.py
@@ -71,7 +71,6 @@ class StructureWidget(QtWidgets.QWidget):
         This function is called whenever the QWidget is right clicked.
         This creates a right click menu for the widget.
         """
-        print("here")
         # Part 1: Construct context menu
         menu = QtWidgets.QMenu(self)
         menu.setStyleSheet("QMenu::item::selected {background-color: #9370DB}")


### PR DESCRIPTION
This PR addresses issue number #1579: The +- magnifiers are not working
I'm not sure why this is an issue in PySide6 and not in PyQt5, but it is because the class ActionHandler called the zoom_in and zoom_out function from class dicom_view.
It is better to wrap the zoom functions inside class MainPage anyway to comply with the Encapsulation principle in OOP.