### PR TITLE
Remove old QWidgets in Main Window

### DIFF
--- a/src/View/mainpage/MainPage.py
+++ b/src/View/mainpage/MainPage.py
@@ -84,11 +84,15 @@ class UIMainWindow:
             self.structures_tab = StructureTab()
             self.structures_tab.request_update_structures.connect(self.update_views)
             self.left_panel.addTab(self.structures_tab, "Structures")
+        elif hasattr(self, 'structures_tab'):
+            del self.structures_tab
 
         if patient_dict_container.has_modality("rtdose"):
             self.isodoses_tab = IsodoseTab()
             self.isodoses_tab.request_update_isodoses.connect(self.update_views)
             self.left_panel.addTab(self.isodoses_tab, "Isodoses")
+        elif hasattr(self, 'isodoses_tab'):
+            del self.isodoses_tab
 
         # Hide left panel if no rtss or rtdose
         if not patient_dict_container.has_modality("rtss") and not patient_dict_container.has_modality("rtdose"):
@@ -107,6 +111,8 @@ class UIMainWindow:
         if patient_dict_container.has_modality("rtss") and patient_dict_container.has_modality("rtdose"):
             self.dvh_tab = DVHTab()
             self.right_panel.addTab(self.dvh_tab, "DVH")
+        elif hasattr(self, 'dvh_tab'):
+            del self.dvh_tab
 
         self.dicom_tree = DicomTreeView()
         self.right_panel.addTab(self.dicom_tree, "DICOM Tree")


### PR DESCRIPTION
This PR fixes the following issue: (Bug #1600 on Team23's Redmine Page)
Please follow the following steps to reproduce the problem:
1. Open a patient with RTDOSE and RTSTRUCT (Calculate DVH)
2. Then open another patient without RTDOSE and/or RTSTRUCT
3. Then perform any functionality related to RTDOSE and/or RTSTRUCT in the new patient. (E.g. Change Line & Fill Configuration)
4. Application fails