### PR TITLE
Bug/fix open patient window bugs

### DIFF
--- a/src/View/OpenPatientWindow.py
+++ b/src/View/OpenPatientWindow.py
@@ -196,6 +196,7 @@ class UIOpenPatientWindow(object):
 
     def scan_directory_for_patient(self):
         # Reset tree view header and last patient
+        self.open_patient_window_confirm_button.setDisabled(True)
         self.open_patient_window_patients_tree.setHeaderLabels([""])
         self.last_patient = None
         self.filepath = self.open_patient_directory_input_box.text()


### PR DESCRIPTION
This PR fixes the problems described in tickets **#1605** and **#1580** on Team 23's Redmine page.

- When a new directory is scanned, the program disables the "Confirm" button in the Open patient window.
- If more than 1 study is selected, the program will disable the "Confirm" button and display a warning message in the DICOM tree's header.