### PR TITLE
Bug/Fix Draw ROI window

### DIFF
--- a/src/View/mainpage/DeleteROIWindow.py
+++ b/src/View/mainpage/DeleteROIWindow.py
@@ -180,7 +180,7 @@ class UIDeleteROIWindow():
         self.delete_roi_window_cancel_button.resize(self.delete_roi_window_cancel_button.sizeHint().width(),
                                      self.delete_roi_window_cancel_button.sizeHint().height())
         self.delete_roi_window_cancel_button.setCursor(QtGui.QCursor(QtCore.Qt.PointingHandCursor))
-        self.delete_roi_window_cancel_button.clicked.connect(self.on_cancel_button_clicked)
+        self.delete_roi_window_cancel_button.clicked.connect(self.onCancelButtonClicked)
         self.delete_roi_window_cancel_button.setProperty("QPushButtonClass", "fail-button")
         self.delete_roi_window_action_buttons_box.addStretch(1)
         self.delete_roi_window_action_buttons_box.addWidget(self.delete_roi_window_cancel_button)
@@ -233,7 +233,7 @@ class UIDeleteROIWindow():
         self.delete_roi_window_cancel_button.setText(_translate("DeleteRoiWindowCancelButton", "Cancel"))
         self.delete_roi_window_confirm_button.setText(_translate("DeleteRoiWindowConfirmButton", "Confirm"))
 
-    def on_cancel_button_clicked(self):
+    def onCancelButtonClicked(self):
         self.close()
 
     def display_rois_in_listViewKeep(self):

--- a/src/View/mainpage/DrawROIWindow.py
+++ b/src/View/mainpage/DrawROIWindow.py
@@ -162,7 +162,7 @@ class UIDrawROIWindow:
         icon_zoom_in = QtGui.QIcon()
         icon_zoom_in.addPixmap(QtGui.QPixmap(resource_path('res/images/btn-icons/zoom_in_icon.png')))
         self.draw_roi_window_viewport_zoom_in_button.setIcon(icon_zoom_in)
-        self.draw_roi_window_viewport_zoom_in_button.clicked.connect(self.on_zoom_in_clicked)
+        self.draw_roi_window_viewport_zoom_in_button.clicked.connect(self.onZoomInClicked)
         # Zoom Out Button
         self.draw_roi_window_viewport_zoom_out_button = QPushButton()
         self.draw_roi_window_viewport_zoom_out_button.setObjectName("DrawRoiWindowViewportZoomOutButton")
@@ -173,7 +173,7 @@ class UIDrawROIWindow:
         icon_zoom_out = QtGui.QIcon()
         icon_zoom_out.addPixmap(QtGui.QPixmap(resource_path('res/images/btn-icons/zoom_out_icon.png')))
         self.draw_roi_window_viewport_zoom_out_button.setIcon(icon_zoom_out)
-        self.draw_roi_window_viewport_zoom_out_button.clicked.connect(self.on_zoom_out_clicked)
+        self.draw_roi_window_viewport_zoom_out_button.clicked.connect(self.onZoomOutClicked)
         self.draw_roi_window_viewport_zoom_box.addWidget(self.draw_roi_window_viewport_zoom_label)
         self.draw_roi_window_viewport_zoom_box.addWidget(self.draw_roi_window_viewport_zoom_input)
         self.draw_roi_window_viewport_zoom_box.addWidget(self.draw_roi_window_viewport_zoom_out_button)
@@ -192,7 +192,7 @@ class UIDrawROIWindow:
         self.image_slice_number_move_backward_button.resize(
             self.image_slice_number_move_backward_button.sizeHint().width(),
             self.image_slice_number_move_backward_button.sizeHint().height())
-        self.image_slice_number_move_backward_button.clicked.connect(self.on_backward_clicked)
+        self.image_slice_number_move_backward_button.clicked.connect(self.onBackwardClicked)
         icon_move_backward = QtGui.QIcon()
         icon_move_backward.addPixmap(QtGui.QPixmap(resource_path('res/images/btn-icons/backward_slide_icon.png')))
         self.image_slice_number_move_backward_button.setIcon(icon_move_backward)
@@ -205,7 +205,7 @@ class UIDrawROIWindow:
         self.image_slice_number_move_forward_button.resize(
             self.image_slice_number_move_forward_button.sizeHint().width(),
             self.image_slice_number_move_forward_button.sizeHint().height())
-        self.image_slice_number_move_forward_button.clicked.connect(self.on_forward_clicked)
+        self.image_slice_number_move_forward_button.clicked.connect(self.onForwardClicked)
         icon_move_forward = QtGui.QIcon()
         icon_move_forward.addPixmap(QtGui.QPixmap(resource_path('res/images/btn-icons/forward_slide_icon.png')))
         self.image_slice_number_move_forward_button.setIcon(icon_move_forward)
@@ -239,7 +239,7 @@ class UIDrawROIWindow:
             self.image_slice_number_box_draw_button.sizeHint().width(),
             self.image_slice_number_box_draw_button.sizeHint().height()
         )
-        self.image_slice_number_box_draw_button.clicked.connect(self.on_box_draw_clicked)
+        self.image_slice_number_box_draw_button.clicked.connect(self.onBoxDrawClicked)
         icon_box_draw = QtGui.QIcon()
         icon_box_draw.addPixmap(QtGui.QPixmap(resource_path('res/images/btn-icons/draw_bound_icon.png')))
         self.image_slice_number_box_draw_button.setIcon(icon_box_draw)
@@ -252,7 +252,7 @@ class UIDrawROIWindow:
         self.image_slice_number_draw_button.resize(
             self.image_slice_number_draw_button.sizeHint().width(),
             self.image_slice_number_draw_button.sizeHint().height())
-        self.image_slice_number_draw_button.clicked.connect(self.on_draw_clicked)
+        self.image_slice_number_draw_button.clicked.connect(self.onDrawClicked)
         icon_draw = QtGui.QIcon()
         icon_draw.addPixmap(QtGui.QPixmap(resource_path('res/images/btn-icons/draw_icon.png')))
         self.image_slice_number_draw_button.setIcon(icon_draw)
@@ -262,7 +262,7 @@ class UIDrawROIWindow:
         # Create a contour preview button and alpha selection input
         self.row_preview_layout = QtWidgets.QHBoxLayout()
         self.button_contour_preview = QtWidgets.QPushButton("Preview contour")
-        self.button_contour_preview.clicked.connect(self.on_preview_clicked)
+        self.button_contour_preview.clicked.connect(self.onPreviewClicked)
         self.label_alpha_value = QtWidgets.QLabel("Alpha value:")
         self.input_alpha_value = QtWidgets.QLineEdit("0.2")
         self.row_preview_layout.addWidget(self.button_contour_preview)
@@ -329,7 +329,7 @@ class UIDrawROIWindow:
         self.draw_roi_window_instance_action_reset_button.resize(
             self.draw_roi_window_instance_action_reset_button.sizeHint().width(),
             self.draw_roi_window_instance_action_reset_button.sizeHint().height())
-        self.draw_roi_window_instance_action_reset_button.clicked.connect(self.on_reset_clicked)
+        self.draw_roi_window_instance_action_reset_button.clicked.connect(self.onResetClicked)
         self.draw_roi_window_instance_action_reset_button.setProperty("QPushButtonClass", "fail-button")
         icon_clear_roi_draw = QtGui.QIcon()
         icon_clear_roi_draw.addPixmap(QtGui.QPixmap(resource_path('res/images/btn-icons/reset_roi_draw_icon.png')))
@@ -349,7 +349,7 @@ class UIDrawROIWindow:
         self.draw_roi_window_instance_cancel_button.resize(self.draw_roi_window_instance_cancel_button.sizeHint().width(),
                                                     self.draw_roi_window_instance_cancel_button.sizeHint().height())
         self.draw_roi_window_instance_cancel_button.setCursor(QtGui.QCursor(QtCore.Qt.PointingHandCursor))
-        self.draw_roi_window_instance_cancel_button.clicked.connect(self.on_cancel_button_clicked)
+        self.draw_roi_window_instance_cancel_button.clicked.connect(self.onCancelButtonClicked)
         self.draw_roi_window_instance_cancel_button.setProperty("QPushButtonClass", "fail-button")
         icon_cancel = QtGui.QIcon()
         icon_cancel.addPixmap(QtGui.QPixmap(resource_path('res/images/btn-icons/cancel_icon.png')))
@@ -367,8 +367,9 @@ class UIDrawROIWindow:
         icon_save = QtGui.QIcon()
         icon_save.addPixmap(QtGui.QPixmap(resource_path('res/images/btn-icons/save_icon.png')))
         self.draw_roi_window_instance_save_button.setIcon(icon_save)
-        self.draw_roi_window_instance_save_button.clicked.connect(self.on_save_clicked)
+        self.draw_roi_window_instance_save_button.clicked.connect(self.onSaveClicked)
         self.draw_roi_window_cancel_save_box.addWidget(self.draw_roi_window_instance_save_button)
+
         self.draw_roi_window_input_container_box.addRow(self.draw_roi_window_cancel_save_box)
 
 
@@ -405,7 +406,7 @@ class UIDrawROIWindow:
     def slider_value_changed(self):
         self.image_slice_number_line_edit.setText(str(self.dicom_view.current_slice_number))
 
-    def on_zoom_in_clicked(self):
+    def onZoomInClicked(self):
         """
         This function is used for zooming in button
         """
@@ -414,7 +415,7 @@ class UIDrawROIWindow:
         self.draw_roi_window_viewport_zoom_input.setText("{:.2f}".format(self.dicom_view.zoom * 100) + "%")
         self.draw_roi_window_viewport_zoom_input.setCursorPosition(0)
 
-    def on_zoom_out_clicked(self):
+    def onZoomOutClicked(self):
         """
         This function is used for zooming out button
         """
@@ -423,13 +424,13 @@ class UIDrawROIWindow:
         self.draw_roi_window_viewport_zoom_input.setText("{:.2f}".format(self.dicom_view.zoom * 100) + "%")
         self.draw_roi_window_viewport_zoom_input.setCursorPosition(0)
 
-    def on_cancel_button_clicked(self):
+    def onCancelButtonClicked(self):
         """
         This function is used for canceling the drawing
         """
         self.close()
 
-    def on_backward_clicked(self):
+    def onBackwardClicked(self):
         self.backward_pressed = True
         self.forward_pressed = False
         self.slider_changed = False
@@ -448,7 +449,7 @@ class UIDrawROIWindow:
             self.image_slice_number_line_edit.setText(str(self.current_slice + 1))
             self.dicom_view.update_view()
 
-    def on_forward_clicked(self):
+    def onForwardClicked(self):
         pixmaps = self.patient_dict_container.get("pixmaps")
         total_slices = len(pixmaps)
 
@@ -468,7 +469,7 @@ class UIDrawROIWindow:
             self.image_slice_number_line_edit.setText(str(self.current_slice + 1))
             self.dicom_view.update_view()
 
-    def on_reset_clicked(self):
+    def onResetClicked(self):
         self.dicom_view.image_display()
         self.dicom_view.update_view()
         self.isthmus_width_max_line_edit.setText("5")
@@ -515,7 +516,7 @@ class UIDrawROIWindow:
 
         self.dicom_view.update_view()
 
-    def on_draw_clicked(self):
+    def onDrawClicked(self):
         """
         Function triggered when the Draw button is pressed from the menu.
         """
@@ -568,7 +569,7 @@ class UIDrawROIWindow:
             else:
                 QMessageBox.about(self.draw_roi_window_instance, "Not Enough Data", "Not all values are specified or correct.")
 
-    def on_box_draw_clicked(self):
+    def onBoxDrawClicked(self):
         id = self.dicom_view.slider.value()
         dt = self.patient_dict_container.dataset[id]
         dt.convert_pixel_data()
@@ -577,7 +578,7 @@ class UIDrawROIWindow:
         self.bounds_box_draw = DrawBoundingBox(pixmaps[id], dt)
         self.dicom_view.view.setScene(self.bounds_box_draw)
 
-    def on_save_clicked(self):
+    def onSaveClicked(self):
         # Make sure the user has clicked Draw first
         if self.ds is not None:
             # Because the contour data needs to be a list of points that form a polygon, the list of pixel points need
@@ -657,7 +658,7 @@ class UIDrawROIWindow:
 
         return contour_data
 
-    def on_preview_clicked(self):
+    def onPreviewClicked(self):
         if hasattr(self, 'drawingROI') and len(self.drawingROI.target_pixel_coords) > 0:
             list_of_points = self.calculate_concave_hull_of_points()
             if list_of_points is not None:


### PR DESCRIPTION
This PR addresses the following issues on Linux systems when opening a Draw ROI window:

qt.core.qmetaobject.connectslotsbyname: QMetaObject::connectSlotsByName: No matching signal for on_zoom_out_clicked()
qt.core.qmetaobject.connectslotsbyname: QMetaObject::connectSlotsByName: No matching signal for on_backward_clicked()
qt.core.qmetaobject.connectslotsbyname: QMetaObject::connectSlotsByName: No matching signal for on_forward_clicked()
qt.core.qmetaobject.connectslotsbyname: QMetaObject::connectSlotsByName: No matching signal for on_box_draw_clicked()
qt.core.qmetaobject.connectslotsbyname: QMetaObject::connectSlotsByName: No matching signal for on_draw_clicked()
qt.core.qmetaobject.connectslotsbyname: QMetaObject::connectSlotsByName: No matching signal for on_preview_clicked()
qt.core.qmetaobject.connectslotsbyname: QMetaObject::connectSlotsByName: No matching signal for on_reset_clicked()
qt.core.qmetaobject.connectslotsbyname: QMetaObject::connectSlotsByName: No matching signal for on_cancel_button_clicked()
qt.core.qmetaobject.connectslotsbyname: QMetaObject::connectSlotsByName: No matching signal for on_save_clicked()

Please note whilst snake_case is the naming convention we follow, it appears to conflict with Qt, thus camelCase is used to fix the above errors. 
