### PR TITLE
Draw ROI window fix

### DIFF
--- a/src/View/mainpage/DicomView.py
+++ b/src/View/mainpage/DicomView.py
@@ -148,7 +148,8 @@ class DicomView(QtWidgets.QWidget):
         if self.patient_dict_container.get("selected_rois"):
             self.roi_display()
 
-        if self.patient_dict_container.get("selected_doses"):
+        # If there are colours set and doses are selected then update the display
+        if self.iso_color and self.patient_dict_container.get("selected_doses"):
             self.isodose_display()
 
         self.update_metadata()

--- a/src/View/mainpage/DicomView.py
+++ b/src/View/mainpage/DicomView.py
@@ -14,6 +14,7 @@ class DicomView(QtWidgets.QWidget):
         QtWidgets.QWidget.__init__(self)
         self.patient_dict_container = PatientDictContainer()
         self.iso_color = iso_color
+        self.roi_color = roi_color
         self.zoom = 1
         self.current_slice_number = None
 
@@ -145,10 +146,11 @@ class DicomView(QtWidgets.QWidget):
         if zoom_change:
             self.view.setTransform(QtGui.QTransform().scale(self.zoom, self.zoom))
 
-        if self.patient_dict_container.get("selected_rois"):
+        # If roi colours are set and rois are selected then update the display
+        if self.roi_color and self.patient_dict_container.get("selected_rois"):
             self.roi_display()
 
-        # If there are colours set and doses are selected then update the display
+        # If isodose colours are set and doses are selected then update the display
         if self.iso_color and self.patient_dict_container.get("selected_doses"):
             self.isodose_display()
 

--- a/src/View/mainpage/DrawROIWindow.py
+++ b/src/View/mainpage/DrawROIWindow.py
@@ -17,7 +17,6 @@ from src.Model import ROI
 from src.Model.GetPatientInfo import DicomTree
 from src.Model.PatientDictContainer import PatientDictContainer
 from src.Model.Worker import Worker
-from src.View.mainpage.IsodoseTab import IsodoseTab
 from src.View.mainpage.DicomView import DicomView
 
 from src.Controller.PathHandler import resource_path
@@ -53,9 +52,7 @@ class UIDrawROIWindow:
         self.upper_limit = None
         self.lower_limit = None
 
-        self.iso_colour_dict = IsodoseTab().color_dict
-
-        self.dicom_view = DicomView(None, self.iso_colour_dict)
+        self.dicom_view = DicomView()
         self.dicom_view.slider.valueChanged.connect(self.slider_value_changed)
         self.init_layout()
 

--- a/src/View/mainpage/DrawROIWindow.py
+++ b/src/View/mainpage/DrawROIWindow.py
@@ -17,6 +17,7 @@ from src.Model import ROI
 from src.Model.GetPatientInfo import DicomTree
 from src.Model.PatientDictContainer import PatientDictContainer
 from src.Model.Worker import Worker
+from src.View.mainpage.IsodoseTab import IsodoseTab
 from src.View.mainpage.DicomView import DicomView
 
 from src.Controller.PathHandler import resource_path
@@ -51,7 +52,10 @@ class UIDrawROIWindow:
 
         self.upper_limit = None
         self.lower_limit = None
-        self.dicom_view = DicomView()
+
+        self.iso_colour_dict = IsodoseTab().color_dict
+
+        self.dicom_view = DicomView(None, self.iso_colour_dict)
         self.dicom_view.slider.valueChanged.connect(self.slider_value_changed)
         self.init_layout()
 


### PR DESCRIPTION
Fixed:
- Opening DrawROI window whilst isodoses are selected caused the program to crash 
- DrawROI displaying ROI or Isodoses 