### PR TITLE
Fix: Patient Selection Highlight

### DIFF
--- a/res/stylesheet-win-linux.qss
+++ b/res/stylesheet-win-linux.qss
@@ -192,21 +192,21 @@ QTreeView::item {
     min-height: 36px;
     font-size: 14px;
 }
-QTreeView::item:hover:!focus {
+QTreeView::item:selected:focus {
+    background-color: #ffffff;
+    color: black;
+    border: 2px solid #9370DB;
+}
+QTreeView::item:selected:!focus {
+    background-color: #5c2eb8;
+    color: white;
+    border: 2px solid #9370DB;
+}
+QTreeView::item:hover:!focus:!selected, QTreeView::item:hover:selected {
     background-color: #b299e6;
 }
-QTreeView::item:focus:!hover {
-    border: 2px solid #9370DB;
-}
-QTreeView::item:selected:hover:!focus, QTreeView::item:selected:hover {
-    background-color: #5c2eb8;
-    color: white;
-    border: 2px solid rgb(200, 200, 200);
-}
-QTreeView::item:selected:!hover:focus {
-    background-color: #5c2eb8;
-    color: white;
-    border: 2px solid #9370DB;
+QTreeView {
+	selection-background-color: transparent;
 }
 QTreeView::indicator {
     width: 30px;

--- a/src/View/OpenPatientWindow.py
+++ b/src/View/OpenPatientWindow.py
@@ -105,7 +105,7 @@ class UIOpenPatientWindow(object):
                                                       self.open_patient_window_patients_tree.sizeHint().height())
         self.open_patient_window_patients_tree.setHeaderHidden(False)
         self.open_patient_window_patients_tree.setHeaderLabels([""])
-        self.open_patient_window_patients_tree.itemChanged.connect(self.tree_item_changed)
+        self.open_patient_window_patients_tree.itemClicked.connect(self.tree_item_clicked)
         self.open_patient_window_instance_vertical_box.addWidget(self.open_patient_window_patients_tree)
         self.last_patient = None
 
@@ -265,13 +265,21 @@ class UIOpenPatientWindow(object):
         if len(dicom_structure.patients) == 0:
             QMessageBox.about(self, "No files found", "Selected directory contains no DICOM files.")
 
-    def tree_item_changed(self, item, _):
+    def tree_item_clicked(self, item, _):
         """
             Executes when a tree item is checked or unchecked.
             If a different patient is checked, uncheck the previous patient.
             Inform user about missing DICOM files.
         """
         selected_patient = item
+
+        # If patient is only selected, but not checked, set it to "focus" to coincide with stylesheet
+        if selected_patient.checkState(0) == Qt.CheckState.Unchecked:
+            self.open_patient_window_patients_tree.setCurrentItem(selected_patient)
+        else: # Otherwise don't "focus", then set patient as selected
+            self.open_patient_window_patients_tree.setCurrentItem(None)
+            selected_patient.setSelected(True)
+
         # If the item is not top-level, bubble up to see which top-level item this item belongs to
         if self.open_patient_window_patients_tree.invisibleRootItem().indexOfChild(item) == -1:
             while self.open_patient_window_patients_tree.invisibleRootItem().indexOfChild(selected_patient) == -1:


### PR DESCRIPTION
Fixed: 
- Patient will only be highlighted in purple if the patient is selected and checked. 
- Patient that is only selected and not checked will have a purple border. 
- Changed the patient's tree's signal from itemChanged to itemClicked, avoids repetitive calls as selecting a child leaf will change the parenting leaf, causing the same method to be called repetitively.  