### PR TITLE
fix matplotlib support issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ git+https://github.com/Radiomics/pyradiomics.git
 pytest-qt>=4.0.2
 pytest
 pyside6
-git+https://github.com/anntzer/matplotlib.git@qt6
+matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ git+https://github.com/Radiomics/pyradiomics.git
 pytest-qt>=4.0.2
 pytest
 pyside6
-matplotlib
+git+https://github.com/matplotlib/matplotlib.git


### PR DESCRIPTION
The branch we have been using for matplotlib PySide6 support is now merged. This PR updates `requirements.txt` and update the pipeline. When matplotlib releases version 3.5.0, we should change it to `matplotlib==3.5.0` for a stable version.