### PR TITLE
Fix anonymising saving to wrong directory

### DIFF
--- a/src/Controller/ActionHandler.py
+++ b/src/Controller/ActionHandler.py
@@ -306,7 +306,6 @@ class ActionHandler:
 
         if save_reply == QtWidgets.QMessageBox.Yes:
             raw_dvh = self.patient_dict_container.get("raw_dvh")
-            self.__main_page.call_class.reset()
             hashed_path = self.__main_page.call_class.run_anonymization(
                 raw_dvh)
             self.patient_dict_container.set("hashed_path", hashed_path)

--- a/src/Controller/ActionHandler.py
+++ b/src/Controller/ActionHandler.py
@@ -306,6 +306,7 @@ class ActionHandler:
 
         if save_reply == QtWidgets.QMessageBox.Yes:
             raw_dvh = self.patient_dict_container.get("raw_dvh")
+            self.__main_page.call_class.reset()
             hashed_path = self.__main_page.call_class.run_anonymization(
                 raw_dvh)
             self.patient_dict_container.set("hashed_path", hashed_path)

--- a/src/Controller/MainPageController.py
+++ b/src/Controller/MainPageController.py
@@ -1184,6 +1184,13 @@ class MainPageCallClass:
         self.dataset = self.patient_dict_container.dataset
         self.filepaths = self.patient_dict_container.filepaths
 
+    def reset(self):
+        """Resets class variables."""
+        self.patient_dict_container = PatientDictContainer()
+        self.path = self.patient_dict_container.path
+        self.dataset = self.patient_dict_container.dataset
+        self.filepaths = self.patient_dict_container.filepaths
+
     # This function runs Anonymization on button click
     def run_anonymization(self, raw_dvh):
         target_path = anonymize(self.path, self.dataset, self.filepaths,

--- a/src/Controller/MainPageController.py
+++ b/src/Controller/MainPageController.py
@@ -1180,33 +1180,29 @@ class MainPageCallClass:
     # Initialisation function of the controller
     def __init__(self):
         self.patient_dict_container = PatientDictContainer()
-        self.path = self.patient_dict_container.path
-        self.dataset = self.patient_dict_container.dataset
-        self.filepaths = self.patient_dict_container.filepaths
-
-    def reset(self):
-        """Resets class variables."""
-        self.patient_dict_container = PatientDictContainer()
-        self.path = self.patient_dict_container.path
-        self.dataset = self.patient_dict_container.dataset
-        self.filepaths = self.patient_dict_container.filepaths
 
     # This function runs Anonymization on button click
     def run_anonymization(self, raw_dvh):
-        target_path = anonymize(self.path, self.dataset, self.filepaths,
-                                raw_dvh)
+        path = self.patient_dict_container.path
+        dataset = self.patient_dict_container.dataset
+        filepaths = self.patient_dict_container.filepaths
+        target_path = anonymize(path, dataset, filepaths, raw_dvh)
         return target_path
 
     # This function displays the clinical data form
     def display_cd_form(self, tab_window, file_path):
-        self.tab_cd = ClinicalDataForm(
-            tab_window, file_path, self.dataset, self.filepaths)
+        dataset = self.patient_dict_container.dataset
+        filepaths = self.patient_dict_container.filepaths
+        self.tab_cd = ClinicalDataForm(tab_window, file_path, dataset,
+                                       filepaths)
         tab_window.addTab(self.tab_cd, "Clinical Data")
 
     # This function displays the clinical data entries in view mode
     def display_cd_dat(self, tab_window, file_path):
-        self.tab_cd = ClinicalDataDisplay(tab_window, file_path, self.dataset,
-                                          self.filepaths)
+        dataset = self.patient_dict_container.dataset
+        filepaths = self.patient_dict_container.filepaths
+        self.tab_cd = ClinicalDataDisplay(tab_window, file_path, dataset,
+                                          filepaths)
         tab_window.addTab(self.tab_cd, "Clinical Data")
 
     # This function runs Transect on button click


### PR DESCRIPTION
When opening multiple patients, only the first patient that was opened would be anonymised, regardless of what was currently opened.

This was caused by the class `MainPageCallClass`, which wraps and controls the anonymisation function, not being updated whenever a new patient was open. Therefore, the file path and dataset being passed into the anonymisation function would always be the file path and dataset of the first patient that was opened.

This PR fixes this by creating a function to reload and update file path and dataset information in `MainPageCallClass`, and calling this function before anonymising the currently opened patient.