### PR TITLE
Fix Pipeline Fail

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -30,6 +30,7 @@ jobs:
     - name: Test with pytest
       run: |
         pip install pytest
+        sudo apt-get update
         sudo apt-get install xvfb libxkbcommon-x11-0 herbstluftwm libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libopengl0 freeglut3 freeglut3-dev
         # install test data
         sudo apt-get install wget unzip


### PR DESCRIPTION
This PR addresses the issue where the pipeline fails while installing required packages. 
The fix is to perform apt-get update before installing the packages. 

> The sudo apt-get update command is used to download package information from all configured sources.
The sources often defined in /etc/apt/sources.list file and other files located in /etc/apt/sources.list.d/ directory.
So when you run update command, it downloads the package information from the Internet. It is useful to get info on an updated version of packages or their dependencies.