### PR TITLE
Pt view Create and View ROI functionality for Modern CT

### DIFF
--- a/src/Controller/MainPageController.py
+++ b/src/Controller/MainPageController.py
@@ -1003,8 +1003,11 @@ class Transect(QtWidgets.QGraphicsScene):
     def get_distances(self):
         for i, j in self.points:
             if i in range(constant.DEFAULT_WINDOW_SIZE) and j in range(constant.DEFAULT_WINDOW_SIZE):
+                x, y = self.transect_linear_transform(i, j)
+                x_2, y_2 = self.transect_linear_transform(
+                    round(self.pos2.x()), round(self.pos2.y()))
                 self.distances.append(self.calculate_distance(
-                    i, j, round(self.pos2.x()), round(self.pos2.y())))
+                    x, y, x_2, y_2))
         self.distances.reverse()
 
     # This function handles the closing event of the transect graph

--- a/src/Model/ROI.py
+++ b/src/Model/ROI.py
@@ -12,6 +12,9 @@ from pydicom.uid import generate_uid, ImplicitVRLittleEndian
 from src.Model.CalculateImages import *
 from src.Model.PatientDictContainer import PatientDictContainer
 
+from src.View.mainpage.DrawROIWindow.Drawing import linear_transform, \
+    inv_linear_transform
+
 
 def rename_roi(rtss, roi_id, new_name):
     """
@@ -639,12 +642,21 @@ def calc_roi_polygon(curr_roi, curr_slice, dict_rois_contours, pixmap_aspect=1):
 
     list_polygons = []
     pixel_list = dict_rois_contours[curr_roi][curr_slice]
+    patient_dict_container = PatientDictContainer()
+    dataset = patient_dict_container.dataset[0]
+
+
     for i in range(len(pixel_list)):
         list_qpoints = []
         contour = pixel_list[i]
         for point in contour:
-            curr_qpoint = QtCore.QPoint(point[0], point[1] * pixmap_aspect)
-            list_qpoints.append(curr_qpoint)
+            x_t, y_t = inv_linear_transform(
+                point[0], point[1],
+                dataset['Rows'].value, dataset['Columns'].value)
+            for x in x_t:
+                for y in y_t:
+                    curr_qpoint = QtCore.QPoint(x, y * pixmap_aspect)
+                    list_qpoints.append(curr_qpoint)
         curr_polygon = QtGui.QPolygonF(list_qpoints)
         list_polygons.append(curr_polygon)
     return list_polygons

--- a/src/View/mainpage/DrawROIWindow/UIDrawROIWindow.py
+++ b/src/View/mainpage/DrawROIWindow/UIDrawROIWindow.py
@@ -15,7 +15,8 @@ from src.Controller.PathHandler import resource_path
 from src.Model import ROI
 from src.Model.PatientDictContainer import PatientDictContainer
 from src.View.mainpage.DicomAxialView import DicomAxialView
-from src.View.mainpage.DrawROIWindow.Drawing import Drawing
+from src.View.mainpage.DrawROIWindow.Drawing import Drawing, \
+    linear_transform, inv_linear_transform
 from src.View.mainpage.DrawROIWindow.SaveROIProgressWindow import \
     SaveROIProgressWindow
 from src.View.mainpage.DrawROIWindow.DrawBoundingBox import DrawBoundingBox


### PR DESCRIPTION
This PR adds the ability to create and View ROIs for modern PT and adds robustness to creating and viewing ROIs.

This comes from the investigation of a bug where modern CT ROI generation created index out of range errors, investigating revealed it wasn't the PT images themselves but their pixel size. They were not 512x512 but other square sizes (e.g. 256x256, 169x169). This PR adresses this issue by adding and using two functions to scale input positional data and ROI output. This will affect all ROI generation and viewing so please test different image types and ROIs