### PR TITLE
Bug: Fix Segmentation Fault

### DIFF
--- a/src/Controller/GUIController.py
+++ b/src/Controller/GUIController.py
@@ -259,9 +259,14 @@ class MainWindow(QtWidgets.QMainWindow, UIMainWindow):
         moving_dict_container.clear()
 
     def cleanup_pt_ct_viewer(self):
+
         pt_ct_dict_container = PTCTDictContainer()
         pt_ct_dict_container.clear()
         self.pet_ct_tab.initialised = False
+        try:
+            del self.pet_ct_tab
+        except:
+            pass
 
     def closeEvent(self, event: QtGui.QCloseEvent) -> None:
         patient_dict_container = PatientDictContainer()

--- a/src/Controller/TopLevelController.py
+++ b/src/Controller/TopLevelController.py
@@ -80,7 +80,8 @@ class Controller:
             self.main_window.open_patient_window.connect(
                 self.show_open_patient)
             self.main_window.run_pyradiomics.connect(self.show_pyradi_progress)
-            self.main_window.pt_ct_signal.connect(self.show_pt_ct_select_window)
+            self.main_window.pt_ct_signal.connect(
+                self.show_pt_ct_select_window)
 
             # Connect the signal from GUIController
             self.main_window.image_fusion_signal.connect(
@@ -148,6 +149,8 @@ class Controller:
         """
         Loads and activates the OpenPTCTPatientWindow
         """
-        self.pt_ct_window = OpenPTCTPatientWindow(self.default_directory)
-        self.pt_ct_window.go_next_window.connect(self.show_main_window)
+        if not isinstance(self.pt_ct_window, OpenPTCTPatientWindow):
+            self.pt_ct_window = OpenPTCTPatientWindow(self.default_directory)
+            self.pt_ct_window.go_next_window.connect(self.show_main_window)
+
         self.pt_ct_window.show()

--- a/src/Model/PTCTDictContainer.py
+++ b/src/Model/PTCTDictContainer.py
@@ -42,6 +42,11 @@ class PTCTDictContainer(metaclass=Singleton):
         self.path = path
         self.additional_data = kwargs
 
+        self.pt_dataset = None
+        self.pt_filepath = None
+        self.ct_dataset = None
+        self.ct_filepath = None
+
     def set_sorted_files(self, pt_dataset, pt_file, ct_dataset, ct_file):
         """
         Used to store the ct and pt datasets


### PR DESCRIPTION
This PR adresses the issue where multiple instances of OpenPTCTPatientWindow selection can be loaded, when loading the initial data in PTCTDictContainer, it sets all other variables as none, in case the container is populated before the initial values are set.