### PR TITLE
Bug Fixes: Batch Processing 

### DIFF
--- a/res/stylesheet-win-linux.qss
+++ b/res/stylesheet-win-linux.qss
@@ -182,6 +182,14 @@ QLineEdit {
     font-size: 14px;
     background-color: rgb(244, 245, 245);
 }
+
+QLineEdit#BatchROICleaning {
+    min-height: 34px;
+    margin: 2px;
+    padding: 0 2px;
+    border-bottom: none;
+}
+
 QLineEdit:disabled {
     background-color: #b9b9b9;
     color: black;

--- a/res/stylesheet.qss
+++ b/res/stylesheet.qss
@@ -150,6 +150,12 @@ QLineEdit {
     font-size: 14px;
     background-color: rgb(244, 245, 245);
 }
+QLineEdit#BatchROICleaning {
+    min-height: 34px;
+    margin: 2px;
+    padding: 0 2px;
+    border-bottom: none;
+}
 QLineEdit:disabled {
     background-color: #b9b9b9;
     color: black;

--- a/src/View/AddOnOptions.py
+++ b/src/View/AddOnOptions.py
@@ -17,6 +17,7 @@ class UIAddOnOptions(object):
         self.table_ids = None
         self.add_new_window = None
         self.delete_window = None
+        self.standard_organ_name_text = None
         self.add_standard_organ_name = None
         self.import_organ_csv = None
         self.add_standard_volume_name = None
@@ -93,7 +94,7 @@ class UIAddOnOptions(object):
         # Add Table Widgets
         self.option_layout.addWidget(self.table_modules, 1, 0, 1, 3)
         self.option_layout.addWidget(self.table_view, 1, 0, 1, 3)
-        self.option_layout.addWidget(self.table_organ, 1, 0, 1, 3)
+        self.option_layout.addWidget(self.table_organ, 2, 0, 1, 3)
         self.option_layout.addWidget(self.table_volume, 1, 0, 1, 3)
         self.option_layout.addWidget(self.table_roi, 1, 0, 1, 3)
         self.option_layout.addWidget(self.table_ids, 1, 0, 1, 3)
@@ -103,13 +104,16 @@ class UIAddOnOptions(object):
         self.option_layout.addWidget(self.clinical_data_csv_dir_frame,
                                      1, 0, 1, 3)
 
+        # Add Label Widgets
+        self.option_layout.addWidget(self.standard_organ_name_text, 1, 0, 1, 3)
+
         # Add Button Widgets
         self.option_layout.addWidget(self.add_new_window, 2, 2)
         self.option_layout.addWidget(self.delete_window, 2, 1)
         self.option_layout.addWidget(self.delete_roi, 2, 0)
         self.option_layout.addWidget(self.add_new_roi, 2, 2)
-        self.option_layout.addWidget(self.import_organ_csv, 2, 1)
-        self.option_layout.addWidget(self.add_standard_organ_name, 2, 2)
+        self.option_layout.addWidget(self.import_organ_csv, 3, 1)
+        self.option_layout.addWidget(self.add_standard_organ_name, 3, 2)
         self.option_layout.addWidget(self.add_standard_volume_name, 2, 2)
         self.option_layout.addWidget(self.note, 2, 0, 1, 3)
 
@@ -204,6 +208,7 @@ class UIAddOnOptions(object):
             self.add_standard_volume_name.setVisible(False)
             self.add_standard_organ_name.setVisible(False)
             self.import_organ_csv.setVisible(False)
+            self.standard_organ_name_text.setVisible(False)
             self.note.setVisible(False)
             self.fill_options.setVisible(False)
             self.change_default_directory_frame.setVisible(False)
@@ -222,6 +227,7 @@ class UIAddOnOptions(object):
             self.add_standard_volume_name.setVisible(False)
             self.add_standard_organ_name.setVisible(True)
             self.import_organ_csv.setVisible(True)
+            self.standard_organ_name_text.setVisible(True)
             self.note.setVisible(False)
             self.fill_options.setVisible(False)
             self.change_default_directory_frame.setVisible(False)
@@ -240,6 +246,7 @@ class UIAddOnOptions(object):
             self.add_standard_volume_name.setVisible(True)
             self.add_standard_organ_name.setVisible(False)
             self.import_organ_csv.setVisible(False)
+            self.standard_organ_name_text.setVisible(False)
             self.note.setVisible(False)
             self.fill_options.setVisible(False)
             self.change_default_directory_frame.setVisible(False)
@@ -259,6 +266,7 @@ class UIAddOnOptions(object):
             self.add_standard_volume_name.setVisible(False)
             self.add_standard_organ_name.setVisible(False)
             self.import_organ_csv.setVisible(False)
+            self.standard_organ_name_text.setVisible(False)
             self.note.setVisible(False)
             self.fill_options.setVisible(False)
             self.change_default_directory_frame.setVisible(False)
@@ -278,6 +286,7 @@ class UIAddOnOptions(object):
             self.add_standard_volume_name.setVisible(False)
             self.add_standard_organ_name.setVisible(False)
             self.import_organ_csv.setVisible(False)
+            self.standard_organ_name_text.setVisible(False)
             self.note.setVisible(True)
             self.fill_options.setVisible(False)
             self.change_default_directory_frame.setVisible(False)
@@ -290,6 +299,7 @@ class UIAddOnOptions(object):
             self.add_standard_volume_name.setVisible(False)
             self.add_standard_organ_name.setVisible(False)
             self.import_organ_csv.setVisible(False)
+            self.standard_organ_name_text.setVisible(False)
             self.table_modules.setVisible(True)
             self.table_view.setVisible(False)
             self.table_organ.setVisible(False)
@@ -308,6 +318,7 @@ class UIAddOnOptions(object):
             self.add_standard_volume_name.setVisible(False)
             self.add_standard_organ_name.setVisible(False)
             self.import_organ_csv.setVisible(False)
+            self.standard_organ_name_text.setVisible(False)
             self.table_modules.setVisible(False)
             self.table_view.setVisible(False)
             self.table_organ.setVisible(False)
@@ -326,6 +337,7 @@ class UIAddOnOptions(object):
             self.add_standard_volume_name.setVisible(False)
             self.add_standard_organ_name.setVisible(False)
             self.import_organ_csv.setVisible(False)
+            self.standard_organ_name_text.setVisible(False)
             self.table_modules.setVisible(False)
             self.table_view.setVisible(False)
             self.table_organ.setVisible(False)
@@ -343,6 +355,7 @@ class UIAddOnOptions(object):
             self.add_standard_volume_name.setVisible(False)
             self.add_standard_organ_name.setVisible(False)
             self.import_organ_csv.setVisible(False)
+            self.standard_organ_name_text.setVisible(False)
             self.table_modules.setVisible(False)
             self.table_view.setVisible(False)
             self.table_organ.setVisible(False)
@@ -434,9 +447,25 @@ class StandardOrganOptions(object):
         Create the components for the UI of Standard Organ view.
         """
         self.window = window_options
+        self.create_text()
         self.create_add_button()
         self.create_import_csv_button()
         self.create_table_view()
+
+    def create_text(self):
+        """
+        Create text to direct users to a website containing all standard
+        organ names.
+        """
+        text = "Standard Organ Names - search here - " \
+               "<a href=\"https://bioportal.bioontology.org/ontologies/FMA/" \
+               "?p=classes&conceptid=root\">https://bioportal.bioontology." \
+               "org/ontologies/FMA/?p=classes&conceptid=root</a>"
+
+        self.window.standard_organ_name_text = QtWidgets.QLabel(text)
+        self.window.standard_organ_name_text.setWordWrap(True)
+        self.window.standard_organ_name_text.setOpenExternalLinks(True)
+        self.window.standard_organ_name_text.setVisible(False)
 
     def create_add_button(self):
         """

--- a/src/View/BatchProcessingWindow.py
+++ b/src/View/BatchProcessingWindow.py
@@ -15,7 +15,7 @@ from src.View.batchprocessing.Pyrad2PyradSROptions import Pyrad2PyradSROptions
 from src.View.batchprocessing.ROIName2FMAIDOptions import \
     ROIName2FMAIDOptions
 from src.View.batchprocessing.ROINameCleaningOptions import \
-    ROINameCleaningOptions, ROINameCleaningPrefixLabel
+    ROINameCleaningOptions, ROINameCleaningPrefixEntryField
 from src.View.batchprocessing.SUV2ROIOptions import SUV2ROIOptions
 
 
@@ -331,8 +331,11 @@ class UIBatchProcessingWindow(object):
 
                 # Get new name text
                 if isinstance(roi_name_table.cellWidget(i, 2),
-                              ROINameCleaningPrefixLabel):
-                    new_name = roi_name_table.cellWidget(i, 2).text()
+                              ROINameCleaningPrefixEntryField):
+                    new_name = roi_name[0:3] \
+                               + roi_name_table.cellWidget(i, 2).text()
+                    # Remove any whitespace, replace with underscores
+                    new_name = '_'.join(new_name.split())
                 else:
                     new_name = roi_name_table.cellWidget(i, 2).currentText()
 

--- a/src/View/batchprocessing/CSV2ClinicalDataSROptions.py
+++ b/src/View/batchprocessing/CSV2ClinicalDataSROptions.py
@@ -76,7 +76,8 @@ class CSV2ClinicalDataSROptions(QtWidgets.QWidget):
         """
         # Open a file dialog and return chosen directory
         csv_path = QtWidgets.QFileDialog.getOpenFileName(
-            None, "Open Clinical Data File", "", "CSV data files (*.csv)")[0]
+            None, "Open Clinical Data File", "",
+            "CSV data files (*.csv *.CSV)")[0]
 
         # Update file path
         self.set_csv_input_location(csv_path, change_if_modified=True)

--- a/src/View/batchprocessing/ROINameCleaningOptions.py
+++ b/src/View/batchprocessing/ROINameCleaningOptions.py
@@ -74,13 +74,20 @@ class ROINameCleaningDatasetComboBox(QtWidgets.QComboBox):
         # TODO: make changing option do nothing
 
 
-class ROINameCleaningPrefixLabel(QtWidgets.QLabel):
+class ROINameCleaningPrefixEntryField(QtWidgets.QLineEdit):
     """
     This class inherits QLabel to create a custom widget for the Name
     Cleaning ROI table that allows it to be enabled or disabled when the
-    QComboBox in the same row changes. This widget displays the new
-    name for an ROI that has a standard prefix in the wrong case.
+    QComboBox in the same row changes. This widget displays an entry field
+    for entering in a new name for the ROI.
     """
+
+    def __init__(self):
+        """
+        Simple sets the object name to properly set styling.
+        """
+        QtWidgets.QLineEdit.__init__(self)
+        self.setObjectName("BatchROICleaning")
 
     @QtCore.Slot(int)
     def change_enabled(self, index):
@@ -277,13 +284,11 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
             rtss_combo_box = ROINameCleaningDatasetComboBox(dataset_list)
             rtss_combo_box.setStyleSheet(self.stylesheet)
 
-            # Generate new name as label if the ROI has a standard
-            # prefix but in the wrong case. Generate organ combobox
-            # otherwise
-            if roi_name[0:3].upper() in self.volume_prefixes:
-                new_name = roi_name[0:3].upper() + roi_name[3:]
-                name_box = ROINameCleaningPrefixLabel()
-                name_box.setText(new_name)
+            # Create text entry field the ROI has a standard prefix.
+            # Generate organ combobox otherwise.
+            if roi_name[0:3] in self.volume_prefixes:
+                name_box = ROINameCleaningPrefixEntryField()
+                name_box.setEnabled(False)
             else:
                 name_box = \
                     ROINameCleaningOrganComboBox(self.organ_names)

--- a/src/View/batchprocessing/ROINameCleaningOptions.py
+++ b/src/View/batchprocessing/ROINameCleaningOptions.py
@@ -237,9 +237,9 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
                     rois[roi_name] = []
 
                 # Add dataset to the list if the ROI name is not a
-                # standard organ name and does not have a standard prefix
-                if roi_name not in self.organ_names and \
-                        roi_name[0:3] not in self.volume_prefixes:
+                # standard organ name or has a standard prefix
+                if roi_name not in self.organ_names or \
+                        roi_name[0:3] in self.volume_prefixes:
                     rois[roi_name].append(rtss)
 
         # Return if no ROIs found


### PR DESCRIPTION
This PR fixes multiple things, mainly to do with batch processing:
- CSV files with the extension `.CSV` can now be opened in Batch CSV2ClinicalData-SR. 
- Batch ROI Name Cleaning for ROIs with standard prefixes has been fixed and now works properly. Users are given the option to enter in a new name for ROIs with standard prefixes (eg. ISO, SUV). The new name is then prefaced by the same prefix, and used to rename the ROI.
- Text has been added to the standard organ names add-on options window that directs users to a web page containing all standard organ names if they wish to add more. This URL is clickable. 