### PR TITLE
Fix: Select Views for Windowing

### DIFF
--- a/src/Controller/ActionHandler.py
+++ b/src/Controller/ActionHandler.py
@@ -1,13 +1,11 @@
 from src.View.ImageFusion.ImageFusionAxialView import ImageFusionAxialView
 from PySide6 import QtGui, QtWidgets, QtCore
-from PySide6.QtWidgets import QStackedWidget, QMessageBox
+from PySide6.QtWidgets import QStackedWidget
 
-from src.Model.CalculateImages import get_pixmaps
 from src.Model.PatientDictContainer import PatientDictContainer
 from src.Model.MovingDictContainer import MovingDictContainer
 from src.Model.PTCTDictContainer import PTCTDictContainer
 from src.Controller.PathHandler import resource_path
-from src.Model.ImageFusion import get_fused_window
 from src.View.WindowingUI import Windowing
 from src.Model.Windowing import windowing_model
 
@@ -303,6 +301,9 @@ class ActionHandler:
             self.windowing_window.show()
 
     def update_views(self):
+        """
+        function to update all dicom views
+        """
         self.__main_page.update_views(update_3d_window=True)
 
     def anonymization_handler(self):

--- a/src/Model/PTCTModel.py
+++ b/src/Model/PTCTModel.py
@@ -66,7 +66,6 @@ def create_pt_ct_model():
     pt_pixmaps_axial, pt_pixmaps_coronal, pt_pixmaps_sagittal = \
         get_pixmaps(pt_pixel_values, window, level, pt_pixmap_aspect,
                     fusion=True, color="Heat")
-
     pt_ct_dict_container.set("pt_pixmaps_axial", pt_pixmaps_axial)
     pt_ct_dict_container.set("pt_pixmaps_coronal", pt_pixmaps_coronal)
     pt_ct_dict_container.set("pt_pixmaps_sagittal", pt_pixmaps_sagittal)

--- a/src/Model/Windowing.py
+++ b/src/Model/Windowing.py
@@ -1,0 +1,70 @@
+from src.Model.PatientDictContainer import PatientDictContainer
+from src.Model.PTCTDictContainer import PTCTDictContainer
+from src.Model.CalculateImages import get_pixmaps
+from src.Model.ImageFusion import get_fused_window
+
+
+def windowing_model(text, init):
+    """
+    Function triggered when a window is selected from the menu.
+    :param text: The name of the window selected.
+    :param init: whether the
+    """
+    patient_dict_container = PatientDictContainer()
+    pt_ct_dict_container = PTCTDictContainer()
+
+    # Get the values for window and level from the dict
+    windowing_limits = patient_dict_container.get("dict_windowing")[text]
+
+    # Set window and level to the new values
+    window = windowing_limits[0]
+    level = windowing_limits[1]
+
+    # Update the dictionary of pixmaps with the update window and
+    # level values
+    if init[0]:
+        pixel_values = patient_dict_container.get("pixel_values")
+        pixmap_aspect = patient_dict_container.get("pixmap_aspect")
+        pixmaps_axial, pixmaps_coronal, pixmaps_sagittal = \
+            get_pixmaps(pixel_values, window, level, pixmap_aspect)
+
+        patient_dict_container.set("pixmaps_axial", pixmaps_axial)
+        patient_dict_container.set("pixmaps_coronal", pixmaps_coronal)
+        patient_dict_container.set("pixmaps_sagittal", pixmaps_sagittal)
+        patient_dict_container.set("window", window)
+        patient_dict_container.set("level", level)
+
+    # Update CT
+    if init[2]:
+        ct_pixel_values = pt_ct_dict_container.get("ct_pixel_values")
+        ct_pixmap_aspect = pt_ct_dict_container.get("ct_pixmap_aspect")
+        ct_pixmaps_axial, ct_pixmaps_coronal, ct_pixmaps_sagittal = \
+            get_pixmaps(ct_pixel_values, window, level, ct_pixmap_aspect,
+                        fusion=True)
+
+        pt_ct_dict_container.set("ct_pixmaps_axial", ct_pixmaps_axial)
+        pt_ct_dict_container.set("ct_pixmaps_coronal", ct_pixmaps_coronal)
+        pt_ct_dict_container.set("ct_pixmaps_sagittal", ct_pixmaps_sagittal)
+        pt_ct_dict_container.set("ct_window", window)
+        pt_ct_dict_container.set("ct_level", level)
+
+    # Update PT
+    if init[1]:
+        pt_pixel_values = pt_ct_dict_container.get("pt_pixel_values")
+        pt_pixmap_aspect = pt_ct_dict_container.get("pt_pixmap_aspect")
+        pt_pixmaps_axial, pt_pixmaps_coronal, pt_pixmaps_sagittal = \
+            get_pixmaps(pt_pixel_values, window, level, pt_pixmap_aspect,
+                        fusion=True, color="Heat")
+
+        pt_ct_dict_container.set("pt_pixmaps_axial", pt_pixmaps_axial)
+        pt_ct_dict_container.set("pt_pixmaps_coronal", pt_pixmaps_coronal)
+        pt_ct_dict_container.set("pt_pixmaps_sagittal", pt_pixmaps_sagittal)
+        pt_ct_dict_container.set("pt_window", window)
+        pt_ct_dict_container.set("pt_level", level)
+
+    if init[3]:
+        fusion_axial, fusion_coronal, fusion_sagittal = \
+            get_fused_window(level, window)
+        patient_dict_container.set("color_axial", fusion_axial)
+        patient_dict_container.set("color_coronal", fusion_coronal)
+        patient_dict_container.set("color_sagittal", fusion_sagittal)

--- a/src/Model/Windowing.py
+++ b/src/Model/Windowing.py
@@ -8,7 +8,7 @@ def windowing_model(text, init):
     """
     Function triggered when a window is selected from the menu.
     :param text: The name of the window selected.
-    :param init: whether the
+    :param init: list of bool to determine which views are chosen
     """
     patient_dict_container = PatientDictContainer()
     pt_ct_dict_container = PTCTDictContainer()
@@ -62,6 +62,7 @@ def windowing_model(text, init):
         pt_ct_dict_container.set("pt_window", window)
         pt_ct_dict_container.set("pt_level", level)
 
+    # Update Fusion
     if init[3]:
         fusion_axial, fusion_coronal, fusion_sagittal = \
             get_fused_window(level, window)

--- a/src/Model/Windowing.py
+++ b/src/Model/Windowing.py
@@ -1,5 +1,6 @@
 from src.Model.PatientDictContainer import PatientDictContainer
 from src.Model.PTCTDictContainer import PTCTDictContainer
+from src.Model.MovingDictContainer import MovingDictContainer
 from src.Model.CalculateImages import get_pixmaps
 from src.Model.ImageFusion import get_fused_window
 
@@ -11,6 +12,7 @@ def windowing_model(text, init):
     :param init: list of bool to determine which views are chosen
     """
     patient_dict_container = PatientDictContainer()
+    moving_dict_container = MovingDictContainer()
     pt_ct_dict_container = PTCTDictContainer()
 
     # Get the values for window and level from the dict
@@ -64,8 +66,9 @@ def windowing_model(text, init):
 
     # Update Fusion
     if init[3]:
-        fusion_axial, fusion_coronal, fusion_sagittal = \
+        fusion_axial, fusion_coronal, fusion_sagittal, tfm = \
             get_fused_window(level, window)
         patient_dict_container.set("color_axial", fusion_axial)
         patient_dict_container.set("color_coronal", fusion_coronal)
         patient_dict_container.set("color_sagittal", fusion_sagittal)
+        moving_dict_container.set("tfm", tfm)

--- a/src/View/WindowingUI.py
+++ b/src/View/WindowingUI.py
@@ -1,0 +1,91 @@
+from PySide6 import QtWidgets, QtCore
+from PySide6.QtWidgets import QDialog, QLabel, QVBoxLayout, QHBoxLayout
+from PySide6.QtGui import QIcon, QPixmap
+
+import platform
+from src.Controller.PathHandler import resource_path
+
+from src.Model.PTCTDictContainer import PTCTDictContainer
+from src.Model.MovingDictContainer import MovingDictContainer
+
+from src.Model.Windowing import windowing_model
+
+
+class Windowing(QDialog):
+
+    done_signal = QtCore.Signal()
+
+    def __init__(self, text):
+        super(Windowing, self).__init__()
+
+        pt_ct_dict_container = PTCTDictContainer()
+        moving_dict_container = MovingDictContainer()
+
+        if platform.system() == 'Darwin':
+            self.stylesheet_path = "res/stylesheet.qss"
+        else:
+            self.stylesheet_path = "res/stylesheet-win-linux.qss"
+
+        self.stylesheet = open(resource_path(self.stylesheet_path)).read()
+
+        window_icon = QIcon()
+        window_icon.addPixmap(QPixmap(resource_path("res/images/icon.ico")),
+                              QIcon.Normal, QIcon.Off)
+
+        self.setWindowIcon(window_icon)
+        self.setStyleSheet(self.stylesheet)
+
+        self.text = text
+
+        self.layout = QVBoxLayout()
+        self.buttons = QHBoxLayout()
+
+        self.setWindowTitle("Select Windows")
+
+        self.label = QLabel("Select Windows to apply to")
+        self.normal = QtWidgets.QCheckBox("DICOM View")
+        self.pet = QtWidgets.QCheckBox("PET/CT: PET")
+        self.ct = QtWidgets.QCheckBox("PET/CT: CT")
+        self.fusion = QtWidgets.QCheckBox("Image Fusion")
+        self.confirm = QtWidgets.QPushButton("Confirm")
+        self.cancel = QtWidgets.QPushButton("Cancel")
+
+        self.confirm.clicked.connect(self.confirmed)
+        self.cancel.clicked.connect(self.exit_button)
+
+        self.buttons.addWidget(self.cancel)
+        self.buttons.addWidget(self.confirm)
+
+        self.layout.addWidget(self.label)
+        self.layout.addWidget(self.normal)
+        if not pt_ct_dict_container.is_empty():
+            self.layout.addWidget(self.pet)
+            self.layout.addWidget(self.ct)
+        if not moving_dict_container.is_empty():
+            self.layout.addWidget(self.fusion)
+        self.layout.addLayout(self.buttons)
+
+        self.setLayout(self.layout)
+
+    def confirmed(self):
+        send = [
+            self.normal.isChecked(),
+            self.pet.isChecked(),
+            self.ct.isChecked(),
+            self.fusion.isChecked()]
+        windowing_model(self.text, send)
+        self.cleanup()
+        self.done_signal.emit()
+
+    def set_window(self, text):
+        self.text = text
+
+    def exit_button(self):
+        self.cleanup()
+
+    def cleanup(self):
+        self.normal.setChecked(False)
+        self.pet.setChecked(False)
+        self.ct.setChecked(False)
+        self.fusion.setChecked(False)
+        self.close()

--- a/src/View/WindowingUI.py
+++ b/src/View/WindowingUI.py
@@ -12,14 +12,17 @@ from src.Model.Windowing import windowing_model
 
 
 class Windowing(QDialog):
-
     done_signal = QtCore.Signal()
 
     def __init__(self, text):
+        """
+        Initialises the widget
+        :param text: the window selected
+        """
         super(Windowing, self).__init__()
 
-        pt_ct_dict_container = PTCTDictContainer()
-        moving_dict_container = MovingDictContainer()
+        self.pt_ct_dict_container = PTCTDictContainer()
+        self.moving_dict_container = MovingDictContainer()
 
         if platform.system() == 'Darwin':
             self.stylesheet_path = "res/stylesheet.qss"
@@ -40,9 +43,9 @@ class Windowing(QDialog):
         self.layout = QVBoxLayout()
         self.buttons = QHBoxLayout()
 
-        self.setWindowTitle("Select Windows")
+        self.setWindowTitle("Select Views")
 
-        self.label = QLabel("Select Windows to apply to")
+        self.label = QLabel("Select views to apply windowing to:")
         self.normal = QtWidgets.QCheckBox("DICOM View")
         self.pet = QtWidgets.QCheckBox("PET/CT: PET")
         self.ct = QtWidgets.QCheckBox("PET/CT: CT")
@@ -51,23 +54,28 @@ class Windowing(QDialog):
         self.cancel = QtWidgets.QPushButton("Cancel")
 
         self.confirm.clicked.connect(self.confirmed)
+        self.confirm.setProperty("QPushButtonClass", "success-button")
         self.cancel.clicked.connect(self.exit_button)
+        self.cancel.setProperty("QPushButtonClass", "fail-button")
 
         self.buttons.addWidget(self.cancel)
         self.buttons.addWidget(self.confirm)
 
         self.layout.addWidget(self.label)
         self.layout.addWidget(self.normal)
-        if not pt_ct_dict_container.is_empty():
+        if not self.pt_ct_dict_container.is_empty():
             self.layout.addWidget(self.pet)
             self.layout.addWidget(self.ct)
-        if not moving_dict_container.is_empty():
+        if not self.moving_dict_container.is_empty():
             self.layout.addWidget(self.fusion)
         self.layout.addLayout(self.buttons)
 
         self.setLayout(self.layout)
 
     def confirmed(self):
+        """
+        Triggers when confirm button is clicked
+        """
         send = [
             self.normal.isChecked(),
             self.pet.isChecked(),
@@ -78,12 +86,21 @@ class Windowing(QDialog):
         self.done_signal.emit()
 
     def set_window(self, text):
+        """
+        Sets the windowing option
+        """
         self.text = text
 
     def exit_button(self):
+        """
+        Triggers on exit
+        """
         self.cleanup()
 
     def cleanup(self):
+        """
+        Resets window for next use
+        """
         self.normal.setChecked(False)
         self.pet.setChecked(False)
         self.ct.setChecked(False)

--- a/src/View/mainpage/MainPage.py
+++ b/src/View/mainpage/MainPage.py
@@ -187,7 +187,7 @@ class UIMainWindow:
 
         # Add PETVT View to right panel as a tab
         self.pet_ct_tab = PetCtView()
-        self.right_panel.addTab(self.pet_ct_tab, "PETCT View")
+        self.right_panel.addTab(self.pet_ct_tab, "PET/CT View")
 
         # Add DVH tab to right panel as a tab
         if patient_dict_container.has_modality("rtdose"):


### PR DESCRIPTION
This PR adds the ability to specify the views to apply a window on:
- If DICOM view is the only active view, then windowing is automatically applied to DICOM view
- If PET/CT view or Image Fusion view is active, a popup will open with checkboxes for each active view
- The checkboxes can be selected and multiple views can be updated at the same time

This PR also moves the windowing function in src.Controller.ActionHandler to src.Model.Windowing to comply with MVC