### PR TITLE
Bug Fix: Batch Processing Unit Tests

### DIFF
--- a/test/test_model_batch_processes.py
+++ b/test/test_model_batch_processes.py
@@ -9,6 +9,7 @@ from PySide6.QtWidgets import QApplication
 from src.Controller.BatchProcessingController import BatchProcessingController
 from src.Model import DICOMDirectorySearch
 from src.Model import DICOMStructuredReport
+from src.Model import ROI
 from src.Model.batchprocessing.BatchProcessClinicalDataSR2CSV import \
     BatchProcessClinicalDataSR2CSV
 from src.Model.batchprocessing.BatchProcessCSV2ClinicalDataSR import \
@@ -118,6 +119,13 @@ def test_batch_iso2roi(test_object):
         difference = set(test_object.iso_levels) - set(rois)
         assert len(difference) > 0
 
+        # An rtss.dcm is being created during this batch test - this is
+        # because the existing RTSTRUCT in DICOM-RT-02 does not match the
+        # rest of the dataset. We need to delete this, or future tests
+        # will fail.
+        rtss_path = test_object.batch_dir.joinpath("DICOM-RT-02", "rtss.dcm")
+        os.remove(rtss_path)
+
 
 @pytest.mark.skip()
 def test_batch_suv2roi(test_object):
@@ -191,7 +199,7 @@ def test_batch_dvh2csv(test_object):
         rtdose = process.patient_dict_container.dataset['rtdose']
         assert len(rtdose.DVHSequence) > 0
 
-
+@pytest.mark.skip()
 def test_batch_pyrad2csv(test_object):
     """
     Test asserts creation of CSV as result of PyRad2CSV conversion.
@@ -222,7 +230,7 @@ def test_batch_pyrad2csv(test_object):
         assert os.path.isfile(Path.joinpath(test_object.batch_dir, 'CSV',
                                             filename))
 
-
+@pytest.mark.skip()
 def test_batch_pyrad2pyradsr(test_object):
     """
     Test that a DICOM file 'PyRadiomics-SR.dcm' is created from

--- a/test/test_model_batch_processes.py
+++ b/test/test_model_batch_processes.py
@@ -199,7 +199,7 @@ def test_batch_dvh2csv(test_object):
         rtdose = process.patient_dict_container.dataset['rtdose']
         assert len(rtdose.DVHSequence) > 0
 
-@pytest.mark.skip()
+
 def test_batch_pyrad2csv(test_object):
     """
     Test asserts creation of CSV as result of PyRad2CSV conversion.
@@ -230,7 +230,7 @@ def test_batch_pyrad2csv(test_object):
         assert os.path.isfile(Path.joinpath(test_object.batch_dir, 'CSV',
                                             filename))
 
-@pytest.mark.skip()
+
 def test_batch_pyrad2pyradsr(test_object):
     """
     Test that a DICOM file 'PyRadiomics-SR.dcm' is created from

--- a/test/test_model_batch_processes.py
+++ b/test/test_model_batch_processes.py
@@ -411,6 +411,8 @@ def test_batch_roi_name_cleaning(test_object):
         # Get RTSS file path, count number of ROIs
         rtss_path = None
         for root, dirs, files in os.walk(test_object.batch_dir, topdown=True):
+            if rtss_path is not None:
+                break
             for name in files:
                 try:
                     ds = dcmread(os.path.join(root, name))


### PR DESCRIPTION
This fixes batch processing unit tests. When the batch ISO2ROI test runs, it creates an `rtss.dcm` file in the batch test data folder. This is because the RTSTRUCT in the test dataset does not strictly match the rest of this dataset when comparing UIDs.

This `rtss.dcm` file interferes with other batch unit tests, causing them to fail. This PR deletes this `rtss.dcm` file after batch ISO2ROI finishes, which fixes the other batch processing unit tests so that they pass.