### PR TITLE
Bug Fix: Addon Options

### DIFF
--- a/src/Controller/AddOnOptionsController.py
+++ b/src/Controller/AddOnOptionsController.py
@@ -707,3 +707,6 @@ class AddOptions:
     def show_add_on_options(self):
         self.options_window.fill_tables()
         self.options_window.show()
+
+    def update_ui(self):
+        self.options_window.image_fusion_add_on_options.get_patients_info()

--- a/src/Controller/GUIController.py
+++ b/src/Controller/GUIController.py
@@ -164,6 +164,7 @@ class MainWindow(QtWidgets.QMainWindow, UIMainWindow):
         create_initial_model()
         self.setup_central_widget()
         self.setup_actions()
+        self.add_on_options_controller.update_ui()
 
         self.action_handler.action_open.triggered.connect(
             self.open_new_patient)

--- a/src/Model/ImageFusion.py
+++ b/src/Model/ImageFusion.py
@@ -325,12 +325,11 @@ def create_fused_model(old_images, new_image):
     fused_image = register_images(old_images, new_image)
     patient_dict_container.set("fused_images", fused_image)
 
-    # Throw Transform Object into function to write dcm file
-    if(fused_image[2]):
+    if fused_image[2]:
         combined_affine = convert_composite_to_affine_transform(
             fused_image[1])
-    affine_matrix = convert_combined_affine_to_matrix(combined_affine)
-    write_transform_to_dcm(affine_matrix)
+        affine_matrix = convert_combined_affine_to_matrix(combined_affine)
+        write_transform_to_dcm(affine_matrix)
 
 
 def get_fused_window(level, window):
@@ -401,14 +400,14 @@ def register_images(image_1, image_2):
         tfm (sitk.CompositeTransform)
     """
 
+    store_object_into_dcm = False
+
     # Check to see if the imageWindowing.csv file exists
     if os.path.exists(data_path('imageFusion.json')):
         # If it exists, read data from file into the dictionary
         with open(data_path("imageFusion.json"),
                   "r") as file_input:
             dict_fusion = json.load(file_input)
-
-        store_object_into_dcm = False
 
         img_ct, tfm = linear_registration(
             image_1,
@@ -424,6 +423,10 @@ def register_images(image_1, image_2):
             default_value=dict_fusion["default_value"],
             verbose=False
         )
+
+        # Flag for when a given registration method is rigid.
+        # As DICOM Frame of Reference Transformation Matrix allows
+        # RIGID, RIGID_SCALE or AFFINE
 
         if dict_fusion["reg_method"] == 'rigid':
             store_object_into_dcm = True

--- a/src/Model/ImageFusion.py
+++ b/src/Model/ImageFusion.py
@@ -190,7 +190,8 @@ def convert_combined_affine_to_matrix(combined_affine):
 
     return overall
 
-#TODO: add support for multiple transformations
+
+# TODO: add support for multiple transformations
 def write_transform_to_dcm(affine_matrix):
     """
     Function to write data of the top(moving) image respective
@@ -325,8 +326,10 @@ def create_fused_model(old_images, new_image):
     patient_dict_container.set("fused_images", fused_image)
 
     # Throw Transform Object into function to write dcm file
-    combined_affine = convert_composite_to_affine_transform(fused_image[1])
-    # test = check_affine_conversion(fused_image[1], combined_affine)
+    #if(fused_image[2]):
+    #    combined_affine = convert_composite_to_affine_transform(
+    #        fused_image[1])
+        # test = check_affine_conversion(fused_image[1], combined_affine)
     affine_matrix = convert_combined_affine_to_matrix(combined_affine)
     write_transform_to_dcm(affine_matrix)
 
@@ -349,7 +352,7 @@ def get_fused_window(level, window):
         tfm (sitk.CompositeTransform): transformation object containing data 
         that is a product from linear_registration
     """
-  
+
     patient_dict_container = PatientDictContainer()
     old_images = patient_dict_container.get("sitk_original")
     fused_image = patient_dict_container.get("fused_images")
@@ -367,7 +370,7 @@ def get_fused_window(level, window):
     color_sagittal = {}
     color_coronal = {}
 
-    windowing = (int(level-CT_RESCALE_INTERCEPT), int(window))
+    windowing = (int(level - CT_RESCALE_INTERCEPT), int(window))
 
     for i in range(axial_slice_count):
         color_axial[i] = \
@@ -406,6 +409,8 @@ def register_images(image_1, image_2):
                   "r") as file_input:
             dict_fusion = json.load(file_input)
 
+        store_object_into_dcm = False
+
         img_ct, tfm = linear_registration(
             image_1,
             image_2,
@@ -420,6 +425,9 @@ def register_images(image_1, image_2):
             default_value=dict_fusion["default_value"],
             verbose=False
         )
+
+        if dict_fusion["reg_method"] == 'rigid':
+            store_object_into_dcm = True
     else:
         # If csv does not exist, initialize registration normally
         img_ct, tfm = linear_registration(
@@ -430,8 +438,9 @@ def register_images(image_1, image_2):
             reg_method='rigid',
             verbose=False
         )
+        store_object_into_dcm = True
 
-    return img_ct, tfm
+    return img_ct, tfm, store_object_into_dcm
 
 
 def get_fused_pixmap(orig_image, fused_image, aspect,
@@ -444,11 +453,12 @@ def get_fused_pixmap(orig_image, fused_image, aspect,
         aspect(Any): currently not used
         slice_num(int): slice number of the array
         view(String): specified flag that can be sagittal, coronal or axial
+        windowing: upper and lower bound for windowing
     windowing: target level and window of the fused image
     Returns:
         pixmap (QtGui.QPixmap): returns the pixmap of co-registered fixed and 
         moving images.
-    """    
+    """
     # Get dimension /could also input dimensions as parameters
     image_array = sitk.GetArrayFromImage(orig_image)
     if view == "sagittal":

--- a/src/Model/ImageFusion.py
+++ b/src/Model/ImageFusion.py
@@ -326,10 +326,9 @@ def create_fused_model(old_images, new_image):
     patient_dict_container.set("fused_images", fused_image)
 
     # Throw Transform Object into function to write dcm file
-    #if(fused_image[2]):
-    #    combined_affine = convert_composite_to_affine_transform(
-    #        fused_image[1])
-        # test = check_affine_conversion(fused_image[1], combined_affine)
+    if(fused_image[2]):
+        combined_affine = convert_composite_to_affine_transform(
+            fused_image[1])
     affine_matrix = convert_combined_affine_to_matrix(combined_affine)
     write_transform_to_dcm(affine_matrix)
 

--- a/src/View/addons/ImageFusionAddOnOption.py
+++ b/src/View/addons/ImageFusionAddOnOption.py
@@ -400,6 +400,9 @@ class ImageFusionOptions(object):
                     'Couldn\'t find the series instance '
                     'UID for the Moving Image.')
 
+        if moving_dict_container.is_empty() and self.moving_image != "":
+            self.moving_image = ""
+
         self.fixed_image_placeholder.setText(str(self.fixed_image))
         self.moving_image_placeholder.setText(str(self.moving_image))
 

--- a/src/View/addons/ImageFusionAddOnOption.py
+++ b/src/View/addons/ImageFusionAddOnOption.py
@@ -108,12 +108,7 @@ class ImageFusionOptions(object):
             = QLabel("This is a placeholder for fixed image")
         self.fixed_image_placeholder.setWordWrap(True)
         self.fixed_image_placeholder.setText(str(self.fixed_image))
-        self.fixed_image_placeholder.setSizePolicy(
-            QSizePolicy.Maximum,
-            QSizePolicy.Maximum)
-        self.fixed_image_placeholder.resize(
-            self.fixed_image_placeholder.sizeHint().width(),
-            self.fixed_image_placeholder.sizeHint().height())
+        self.fixed_image_placeholder.setMaximumSize(200, 50)
 
         self.moving_image_label = QLabel("Moving Image: ")
         moving_image_label_sizePolicy = QSizePolicy(QSizePolicy.Maximum,
@@ -127,12 +122,7 @@ class ImageFusionOptions(object):
         self.moving_image_placeholder = QLabel("This is a placeholder")
         self.moving_image_placeholder.setWordWrap(True)
         self.moving_image_placeholder.setText(str(self.moving_image))
-        self.moving_image_placeholder.setSizePolicy(
-            QSizePolicy.Maximum,
-            QSizePolicy.Maximum)
-        self.moving_image_placeholder.resize(
-            self.moving_image_placeholder.sizeHint().width(),
-            self.moving_image_placeholder.sizeHint().height())
+        self.moving_image_placeholder.setMaximumSize(200, 50)
 
         self.gridLayout.addWidget(self.fixed_image_label, 0, 0)
         self.gridLayout.addWidget(self.fixed_image_placeholder, 0, 1)

--- a/src/View/addons/ImageFusionAddOnOption.py
+++ b/src/View/addons/ImageFusionAddOnOption.py
@@ -22,28 +22,9 @@ class ImageFusionOptions(object):
         self.fixed_image = None
         self.dict = {}
 
-        self.get_patients_info()
-        self.create_view()
         self.setupUi()
-
-    def get_patients_info(self):
-        """
-        Retrieve the patient's study description of the fixed image
-        and for the moving image (if it exists).
-        """
-        patient_dict_container = PatientDictContainer()
-        if not patient_dict_container.is_empty():
-            filename = patient_dict_container.filepaths[0]
-            dicom_tree_slice = DicomTree(filename)
-            dict_tree = dicom_tree_slice.dict
-            self.fixed_image = dict_tree["Series Instance UID"][0]
-
-        moving_dict_container = MovingDictContainer()
-        if not moving_dict_container.is_empty():
-            filename = moving_dict_container.filepaths[0]
-            dicom_tree_slice = DicomTree(filename)
-            dict_tree = dicom_tree_slice.dict
-            self.moving_image = dict_tree["Series Instance UID"][0]
+        self.create_view()
+        self.get_patients_info()
 
     def set_value(self, key, value):
         """
@@ -83,8 +64,8 @@ class ImageFusionOptions(object):
         self.gridLayoutWidget = QWidget()
         self.gridLayout = QtWidgets.QGridLayout(self.gridLayoutWidget)
         self.gridLayout.setSizeConstraint(QLayout.SetDefaultConstraint)
-        self.gridLayout.setContentsMargins(10, 10, 10, 10)
-        self.gridLayout.setVerticalSpacing(7)
+        self.gridLayout.setContentsMargins(0, 0, 0, 0)
+        self.gridLayout.setVerticalSpacing(0)
 
         # Create horizontal spacer in the middle of the grid
         hspacer = QtWidgets.QSpacerItem(QtWidgets.QSizePolicy.Expanding,
@@ -106,7 +87,7 @@ class ImageFusionOptions(object):
 
         self.fixed_image_placeholder \
             = QLabel("This is a placeholder for fixed image")
-        self.fixed_image_placeholder.setWordWrap(True)
+        self.fixed_image_placeholder.setWordWrap(False)
         self.fixed_image_placeholder.setText(str(self.fixed_image))
         self.fixed_image_placeholder.setMaximumSize(200, 50)
 
@@ -120,7 +101,7 @@ class ImageFusionOptions(object):
         self.moving_image_label.setSizePolicy(moving_image_label_sizePolicy)
 
         self.moving_image_placeholder = QLabel("This is a placeholder")
-        self.moving_image_placeholder.setWordWrap(True)
+        self.moving_image_placeholder.setWordWrap(False)
         self.moving_image_placeholder.setText(str(self.moving_image))
         self.moving_image_placeholder.setMaximumSize(200, 50)
 
@@ -338,7 +319,7 @@ class ImageFusionOptions(object):
             msg += 'There was an error setting the optimiser value.\n'
             self.warning_label.setText(msg)
 
-        # Check if all elements in lsit are ints
+        # Check if all elements in list are ints
         if all(isinstance(x, int) for x in self.dict["shrink_factors"]):
             # Shrink_factors is stored as a list in JSON convert the list into
             # a string.
@@ -387,6 +368,40 @@ class ImageFusionOptions(object):
         except ValueError:
             msg += 'There was an error setting the Default Number'
             self.warning_label.setText(msg)
+
+    def get_patients_info(self):
+        """
+        Retrieve the patient's study description of the fixed image
+        and for the moving image (if it exists).
+        """
+        patient_dict_container = PatientDictContainer()
+        if not patient_dict_container.is_empty():
+            filename = patient_dict_container.filepaths[0]
+            dicom_tree_slice = DicomTree(filename)
+            dict_tree = dicom_tree_slice.dict
+            try:
+                self.fixed_image = dict_tree["Series Instance UID"][0]
+            except:
+                self.fixed_image = ""
+                self.warning_label.setText(
+                    'Couldn\'t find the series instance '
+                    'UID for the Fixed Image.')
+
+        moving_dict_container = MovingDictContainer()
+        if not moving_dict_container.is_empty():
+            filename = moving_dict_container.filepaths[0]
+            dicom_tree_slice = DicomTree(filename)
+            dict_tree = dicom_tree_slice.dict
+            try:
+                self.moving_image = dict_tree["Series Instance UID"][0]
+            except:
+                self.moving_image = ""
+                self.warning_label.setText(
+                    'Couldn\'t find the series instance '
+                    'UID for the Moving Image.')
+
+        self.fixed_image_placeholder.setText(str(self.fixed_image))
+        self.moving_image_placeholder.setText(str(self.moving_image))
 
     def get_values_from_UI(self):
         """

--- a/src/View/addons/ImageFusionAddOnOption.py
+++ b/src/View/addons/ImageFusionAddOnOption.py
@@ -36,14 +36,14 @@ class ImageFusionOptions(object):
             filename = patient_dict_container.filepaths[0]
             dicom_tree_slice = DicomTree(filename)
             dict_tree = dicom_tree_slice.dict
-            self.fixed_image = dict_tree["Study Description"][0]
+            self.fixed_image = dict_tree["Series Instance UID"][0]
 
         moving_dict_container = MovingDictContainer()
         if not moving_dict_container.is_empty():
             filename = moving_dict_container.filepaths[0]
             dicom_tree_slice = DicomTree(filename)
             dict_tree = dicom_tree_slice.dict
-            self.moving_image = dict_tree["Study Description"][0]
+            self.moving_image = dict_tree["Series Instance UID"][0]
 
     def set_value(self, key, value):
         """
@@ -106,7 +106,7 @@ class ImageFusionOptions(object):
 
         self.fixed_image_placeholder \
             = QLabel("This is a placeholder for fixed image")
-
+        self.fixed_image_placeholder.setWordWrap(True)
         self.fixed_image_placeholder.setText(str(self.fixed_image))
         self.fixed_image_placeholder.setSizePolicy(
             QSizePolicy.Maximum,
@@ -125,6 +125,7 @@ class ImageFusionOptions(object):
         self.moving_image_label.setSizePolicy(moving_image_label_sizePolicy)
 
         self.moving_image_placeholder = QLabel("This is a placeholder")
+        self.moving_image_placeholder.setWordWrap(True)
         self.moving_image_placeholder.setText(str(self.moving_image))
         self.moving_image_placeholder.setSizePolicy(
             QSizePolicy.Maximum,

--- a/src/View/mainpage/MainPage.py
+++ b/src/View/mainpage/MainPage.py
@@ -432,6 +432,9 @@ class UIMainWindow:
         self.right_panel.addTab(self.image_fusion_view, "Image Fusion")
         self.right_panel.setCurrentWidget(self.image_fusion_view)
 
+        # Update the Add On Option GUI
+        self.add_on_options_controller.update_ui()
+
     def perform_suv2roi(self):
         """
         Performs the SUV2ROI process.


### PR DESCRIPTION
This PR is to fix issues:
1. Key and Value error when attempting to use the Study Description as the fixed and moving labels in the addon options, resulting in a crash.
2. Matrix not existing when attempting other registration methods besides "rigid".

To elaborate key point 2: a rigid matrix can be calculated when _rigid_ mode is selected. Other modes did not result in a rigid matrix with current calculations. DICOM standards allow the Spatial Registration Object to save RIGID, RIGID_SCALE and AFFINE matrices.

This PR also introduces the fix to update the fixed image and moving image labels when opening a new patient.
