### PR TITLE
Bug Fix: Module Incompatibilities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ vtk
 git+https://github.com/matplotlib/matplotlib.git
 shapely==1.8a3
 python-Levenshtein
-opencv-python
+opencv-python<=4.5.3.56


### PR DESCRIPTION
This PR changes the required version of the `opencv-python` module in `requirements.txt`. The requirement has been updated to use the previous version of this module, as the version released a few days ago is incompatible with PyInstaller, which is used to generate the Windows executable.