### PR TITLE
BatchProcessing - Seperate anatomy from GTV/CTV/PTV 

### DIFF
--- a/src/View/BatchProcessingWindow.py
+++ b/src/View/BatchProcessingWindow.py
@@ -323,25 +323,56 @@ class UIBatchProcessingWindow(object):
         if 'roinamecleaning' in selected_processes:
             # Get ROIs, datasets, options
             name_cleaning_options = {}
-            roi_name_table = self.batchnamecleaning_tab.table_roi
-            for i in range(roi_name_table.rowCount()):
-                # Get current ROI name and what to do with it
-                roi_name = roi_name_table.item(i, 0).text()
-                option = roi_name_table.cellWidget(i, 1).currentIndex()
+            organ_name_table = self.batchnamecleaning_tab.table_organ
+            volume_prefix_table = self.batchnamecleaning_tab.table_volume
+            for i in range(organ_name_table.rowCount()):
+                # Get current organ name and what to do with it
+                roi_name = organ_name_table.item(i, 0).text()
+                option = organ_name_table.cellWidget(i, 1).currentIndex()
 
                 # Get new name text
-                if isinstance(roi_name_table.cellWidget(i, 2),
+                if isinstance(organ_name_table.cellWidget(i, 2),
                               ROINameCleaningPrefixEntryField):
                     new_name = roi_name[0:3] \
-                               + roi_name_table.cellWidget(i, 2).text()
+                               + organ_name_table.cellWidget(i, 2).text()
                     # Remove any whitespace, replace with underscores
                     new_name = '_'.join(new_name.split())
                 else:
-                    new_name = roi_name_table.cellWidget(i, 2).currentText()
+                    new_name = organ_name_table.cellWidget(i, 2).currentText()
 
-                # Get the dataset(s) the ROI is in
+                # Get the dataset(s) the organ is in
                 dataset_list = []
-                dataset_combo_box = roi_name_table.cellWidget(i, 3)
+                dataset_combo_box = organ_name_table.cellWidget(i, 3)
+                rtss_path = self.directory_input.text()
+                for index in range(dataset_combo_box.count()):
+                    dataset_list.append(
+                        rtss_path + dataset_combo_box.itemText(index))
+
+                if roi_name not in name_cleaning_options.keys():
+                    name_cleaning_options[roi_name] = []
+
+                for item in dataset_list:
+                    name_cleaning_options[roi_name].append(
+                        [option, new_name, item])
+
+            for i in range(volume_prefix_table.rowCount()):
+                # Get current volume prefix and what to do with it
+                roi_name = volume_prefix_table.item(i, 0).text()
+                option = volume_prefix_table.cellWidget(i, 1).currentIndex()
+
+                # Get new name text
+                if isinstance(volume_prefix_table.cellWidget(i, 2),
+                              ROINameCleaningPrefixEntryField):
+                    new_name = roi_name[0:3] \
+                               + volume_prefix_table.cellWidget(i, 2).text()
+                    # Remove any whitespace, replace with underscores
+                    new_name = '_'.join(new_name.split())
+                else:
+                    new_name = volume_prefix_table.cellWidget(i, 2).currentText()
+
+                # Get the dataset(s) the volume is in
+                dataset_list = []
+                dataset_combo_box = volume_prefix_table.cellWidget(i, 3)
                 rtss_path = self.directory_input.text()
                 for index in range(dataset_combo_box.count()):
                     dataset_list.append(

--- a/src/View/batchprocessing/ROINameCleaningOptions.py
+++ b/src/View/batchprocessing/ROINameCleaningOptions.py
@@ -146,7 +146,8 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
         self.volume_prefixes = []
 
         self.get_standard_names()
-        self.create_table_view()
+        self.create_table_view_organ()
+        self.create_table_view_volume()
         self.setLayout(self.main_layout)
 
     def get_standard_names(self):
@@ -170,46 +171,87 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
                 self.volume_prefixes.append(row[1])
             f.close()
 
-    def create_table_view(self):
+    def create_table_view_organ(self):
         """
         Create a table to display all of the non-standard ROIs and
         options for what to do with them.
         """
         # Create table
-        self.table_roi = QtWidgets.QTableWidget(self)
-        self.table_roi.setStyleSheet(
+        self.table_organ = QtWidgets.QTableWidget(self)
+        self.table_organ.setStyleSheet(
             "background-color: rgb(255, 255, 255);")
-        self.table_roi.setColumnCount(4)
-        self.table_roi.verticalHeader().hide()
+        self.table_organ.setColumnCount(4)
+        self.table_organ.verticalHeader().hide()
         # Note - "New Name" is only enabled if the option "Rename" is
         # selected.
-        self.table_roi.setHorizontalHeaderLabels(
-            [" ROI Name ", " Option ", " New Name ", " Dataset Location "])
+        self.table_organ.setHorizontalHeaderLabels(
+            [" Organ Name ", " Option ", " New Name ", " Dataset Location "])
 
         # Set text align
-        self.table_roi.horizontalHeaderItem(0).setTextAlignment(
+        self.table_organ.horizontalHeaderItem(0).setTextAlignment(
             QtCore.Qt.AlignLeft)
-        self.table_roi.horizontalHeaderItem(1).setTextAlignment(
+        self.table_organ.horizontalHeaderItem(1).setTextAlignment(
             QtCore.Qt.AlignLeft)
-        self.table_roi.horizontalHeaderItem(2).setTextAlignment(
+        self.table_organ.horizontalHeaderItem(2).setTextAlignment(
             QtCore.Qt.AlignLeft)
-        self.table_roi.horizontalHeaderItem(3).setTextAlignment(
+        self.table_organ.horizontalHeaderItem(3).setTextAlignment(
             QtCore.Qt.AlignLeft)
 
         # Set header stretch
-        roi_name_header = self.table_roi.horizontalHeader()
+        roi_name_header = self.table_organ.horizontalHeader()
         roi_name_header.setSectionResizeMode(0, QtWidgets.QHeaderView.Stretch)
         roi_name_header.setSectionResizeMode(1, QtWidgets.QHeaderView.Stretch)
         roi_name_header.setSectionResizeMode(2, QtWidgets.QHeaderView.Stretch)
         roi_name_header.setSectionResizeMode(3, QtWidgets.QHeaderView.Stretch)
 
         # Removing the ability to edit tables with immediate click
-        self.table_roi.setEditTriggers(
+        self.table_organ.setEditTriggers(
             QtWidgets.QTreeView.NoEditTriggers |
             QtWidgets.QTreeView.NoEditTriggers)
 
         # Add table to the main layout
-        self.main_layout.addWidget(self.table_roi)
+        self.main_layout.addWidget(self.table_organ)
+
+    def create_table_view_volume(self):
+        """
+        Create a table to display all of the non-standard ROIs and
+        options for what to do with them.
+        """
+        # Create table
+        self.table_volume = QtWidgets.QTableWidget(self)
+        self.table_volume.setStyleSheet(
+            "background-color: rgb(255, 255, 255);")
+        self.table_volume.setColumnCount(4)
+        self.table_volume.verticalHeader().hide()
+        # Note - "New Name" is only enabled if the option "Rename" is
+        # selected.
+        self.table_volume.setHorizontalHeaderLabels(
+            [" Volume Prefix ", " Option ", " New Name ", " Dataset Location "])
+
+        # Set text align
+        self.table_volume.horizontalHeaderItem(0).setTextAlignment(
+            QtCore.Qt.AlignLeft)
+        self.table_volume.horizontalHeaderItem(1).setTextAlignment(
+            QtCore.Qt.AlignLeft)
+        self.table_volume.horizontalHeaderItem(2).setTextAlignment(
+            QtCore.Qt.AlignLeft)
+        self.table_volume.horizontalHeaderItem(3).setTextAlignment(
+            QtCore.Qt.AlignLeft)
+
+        # Set header stretch
+        roi_name_header = self.table_volume.horizontalHeader()
+        roi_name_header.setSectionResizeMode(0, QtWidgets.QHeaderView.Stretch)
+        roi_name_header.setSectionResizeMode(1, QtWidgets.QHeaderView.Stretch)
+        roi_name_header.setSectionResizeMode(2, QtWidgets.QHeaderView.Stretch)
+        roi_name_header.setSectionResizeMode(3, QtWidgets.QHeaderView.Stretch)
+
+        # Removing the ability to edit tables with immediate click
+        self.table_volume.setEditTriggers(
+            QtWidgets.QTreeView.NoEditTriggers |
+            QtWidgets.QTreeView.NoEditTriggers)
+
+        # Add table to the main layout
+        self.main_layout.addWidget(self.table_volume)
 
     def populate_table(self, dicom_structure, batch_directory):
         """
@@ -219,8 +261,19 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
                                 patients loaded.
         :param batch_directory: The directory selected for batch processing.
         """
-        # Update table column view
-        roi_name_header = self.table_roi.horizontalHeader()
+        # Update table column view organ
+        roi_name_header = self.table_organ.horizontalHeader()
+        roi_name_header.setSectionResizeMode(
+            0, QtWidgets.QHeaderView.Stretch)
+        roi_name_header.setSectionResizeMode(
+            1, QtWidgets.QHeaderView.ResizeToContents)
+        roi_name_header.setSectionResizeMode(
+            2, QtWidgets.QHeaderView.ResizeToContents)
+        roi_name_header.setSectionResizeMode(
+            3, QtWidgets.QHeaderView.ResizeToContents)
+
+        # Update table column view volume
+        roi_name_header = self.table_volume.horizontalHeader()
         roi_name_header.setSectionResizeMode(
             0, QtWidgets.QHeaderView.Stretch)
         roi_name_header.setSectionResizeMode(
@@ -245,7 +298,8 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
 
         # Return if no RT Structs found
         if not len(rtstruct_list):
-            self.table_roi.setRowCount(0)
+            self.table_organ.setRowCount(0)
+            self.table_volume.setRowCount(0)
             return
 
         # Loop through each RT Struct
@@ -278,70 +332,85 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
                 break
 
         if not rois_to_process:
-            self.table_roi.setRowCount(0)
+            self.table_organ.setRowCount(0)
+            self.table_volume.setRowCount(0)
             return
 
         # Populate table
-        self.table_roi.setRowCount(0)
+        self.table_organ.setRowCount(0)
+        self.table_volume.setRowCount(0)
 
         # Loop through each ROI
         i = 0
         for roi_name in rois:
-            # If it is an organ name display otherwise do not 
-            if roi_name.lower() in self.organ_names_lowercase:
-                # Create option combo box
-                combo_box = ROINameCleaningOptionComboBox()
-                combo_box.setStyleSheet(self.stylesheet)
+            # Create option combo box
+            combo_box = ROINameCleaningOptionComboBox()
+            combo_box.setStyleSheet(self.stylesheet)
 
-                # Create dataset combo box
-                # Get list of RTSTRUCTs
-                dataset_list = rois[roi_name]
-                if len(dataset_list) == 0:
-                    continue
+            # Create dataset combo box
+            # Get list of RTSTRUCTs
+            dataset_list = rois[roi_name]
+            if len(dataset_list) == 0:
+                continue
 
-                # Remove common path from RTStructs
-                for index in range(len(dataset_list)):
-                    dataset_list[index] = \
-                        dataset_list[index].replace(batch_directory, '')
+            # Remove common path from RTStructs
+            for index in range(len(dataset_list)):
+                dataset_list[index] = \
+                    dataset_list[index].replace(batch_directory, '')
 
-                rtss_combo_box = ROINameCleaningDatasetComboBox(dataset_list)
-                rtss_combo_box.setStyleSheet(self.stylesheet)
+            rtss_combo_box = ROINameCleaningDatasetComboBox(dataset_list)
+            rtss_combo_box.setStyleSheet(self.stylesheet)
 
-                # Create text entry field the ROI has a standard prefix.
-                # Generate organ combobox otherwise.
-                if roi_name[0:3] in self.volume_prefixes \
-                        or roi_name[0:4] in self.volume_prefixes:
-                    name_box = ROINameCleaningPrefixEntryField()
-                    name_box.setEnabled(False)
+            # Create text entry field the ROI has a standard prefix.
+            # Generate organ combobox otherwise.
+            if roi_name[0:3] in self.volume_prefixes \
+                    or roi_name[0:4] in self.volume_prefixes:
+                name_box = ROINameCleaningPrefixEntryField()
+                name_box.setEnabled(False)
+            else:
+                name_box = \
+                    ROINameCleaningOrganComboBox(self.organ_names,
+                                                self.volume_prefixes,
+                                                roi_name)
+                # Set default combo box entry to organ name in proper case
+                # if the organ name is a standard one.
+                if roi_name.lower() in self.organ_names_lowercase:
+                    index = self.organ_names_lowercase.index(roi_name.lower())
+                    name_box.setCurrentIndex(index)
+                    name_box.setEnabled(True)
+                    combo_box.setCurrentIndex(1)
                 else:
-                    name_box = \
-                        ROINameCleaningOrganComboBox(self.organ_names,
-                                                    self.volume_prefixes,
-                                                    roi_name)
-                    # Set default combo box entry to organ name in proper case
-                    # if the organ name is a standard one.
-                    if roi_name.lower() in self.organ_names_lowercase:
-                        index = self.organ_names_lowercase.index(roi_name.lower())
-                        name_box.setCurrentIndex(index)
-                        name_box.setEnabled(True)
-                        combo_box.setCurrentIndex(1)
-                    else:
-                        name_box.setEnabled(False)
+                    name_box.setEnabled(False)
 
-                combo_box.currentIndexChanged.connect(name_box.change_enabled)
-                name_box.setStyleSheet(self.stylesheet)
+            combo_box.currentIndexChanged.connect(name_box.change_enabled)
+            name_box.setStyleSheet(self.stylesheet)
 
+            if roi_name.lower() in self.organ_names_lowercase:
                 # Add row to table
-                self.table_roi.insertRow(i)
-                self.table_roi.setRowHeight(i, 50)
-                self.table_roi.setItem(
+                self.table_organ.insertRow(i)
+                self.table_organ.setRowHeight(i, 50)
+                self.table_organ.setItem(
                     i, 0, QtWidgets.QTableWidgetItem(roi_name))
-                self.table_roi.setCellWidget(i, 1, combo_box)
-                self.table_roi.setCellWidget(i, 2, name_box)
-                self.table_roi.setCellWidget(i, 3, rtss_combo_box)
-                i += 1
+                self.table_organ.setCellWidget(i, 1, combo_box)
+                self.table_organ.setCellWidget(i, 2, name_box)
+                self.table_organ.setCellWidget(i, 3, rtss_combo_box)
+                continue
+            else:
+                # Add row to table
+                self.table_volume.insertRow(i)
+                self.table_volume.setRowHeight(i, 50)
+                self.table_volume.setItem(
+                    i, 0, QtWidgets.QTableWidgetItem(roi_name))
+                self.table_volume.setCellWidget(i, 1, combo_box)
+                self.table_volume.setCellWidget(i, 2, name_box)
+                self.table_volume.setCellWidget(i, 3, rtss_combo_box)
+            i += 1
 
         # Set row height
-        vertical_header = self.table_roi.verticalHeader()
-        vertical_header.setSectionResizeMode(QtWidgets.QHeaderView.Fixed)
-        vertical_header.setDefaultSectionSize(40)
+        vertical_header_organ = self.table_organ.verticalHeader()
+        vertical_header_organ.setSectionResizeMode(QtWidgets.QHeaderView.Fixed)
+        vertical_header_organ.setDefaultSectionSize(40)
+
+        vertical_header_volume = self.table_volume.verticalHeader()
+        vertical_header_volume.setSectionResizeMode(QtWidgets.QHeaderView.Fixed)
+        vertical_header_volume.setDefaultSectionSize(40)

--- a/src/View/batchprocessing/ROINameCleaningOptions.py
+++ b/src/View/batchprocessing/ROINameCleaningOptions.py
@@ -176,6 +176,7 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
         Create a table to display all of the non-standard ROIs and
         options for what to do with them.
         """
+        logging.info("create_table_view_organ start")
         # Create table
         self.table_organ = QtWidgets.QTableWidget(self)
         self.table_organ.setStyleSheet(
@@ -212,11 +213,14 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
         # Add table to the main layout
         self.main_layout.addWidget(self.table_organ)
 
+        logging.info("create_table_view_organ success")
+
     def create_table_view_volume(self):
         """
         Create a table to display all of the non-standard ROIs and
         options for what to do with them.
         """
+        logging.info("create_table_view_volume start")
         # Create table
         self.table_volume = QtWidgets.QTableWidget(self)
         self.table_volume.setStyleSheet(
@@ -253,6 +257,8 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
         # Add table to the main layout
         self.main_layout.addWidget(self.table_volume)
 
+        logging.info("create_table_view_volume success")
+
     def populate_table(self, dicom_structure, batch_directory):
         """
         Populates the table with ROI names and options once datasets
@@ -261,6 +267,7 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
                                 patients loaded.
         :param batch_directory: The directory selected for batch processing.
         """
+        logging.info("populate_table start")
         # Update table column view organ
         roi_name_header = self.table_organ.horizontalHeader()
         roi_name_header.setSectionResizeMode(
@@ -343,6 +350,7 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
         # Loop through each ROI
         i = 0
         for roi_name in rois:
+            logging.debug("going through roi_name in rois")
             # Create option combo box
             combo_box = ROINameCleaningOptionComboBox()
             combo_box.setStyleSheet(self.stylesheet)
@@ -351,10 +359,12 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
             # Get list of RTSTRUCTs
             dataset_list = rois[roi_name]
             if len(dataset_list) == 0:
+                logging.debug("creating dataset combo box")
                 continue
 
             # Remove common path from RTStructs
             for index in range(len(dataset_list)):
+                logging.debug("removing common path from RTStructs")
                 dataset_list[index] = \
                     dataset_list[index].replace(batch_directory, '')
 
@@ -365,11 +375,13 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
             # Generate organ combobox otherwise.
             if roi_name[0:3] in self.volume_prefixes \
                     or roi_name[0:4] in self.volume_prefixes:
+                logging.debug("if roi_name is volume prefix created text entry field")
                 name_box = ROINameCleaningPrefixEntryField()
                 name_box.setEnabled(False)
             elif roi_name.lower() in self.organ_names_lowercase:
             # Set default combo box entry to organ name in proper case
             # if the organ name is a standard one.
+                logging.debug("if the organ name is a standard one")
                 name_box = \
                 ROINameCleaningOrganComboBox(self.organ_names,
                                             self.volume_prefixes,
@@ -379,6 +391,7 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
                 name_box.setEnabled(True)
                 combo_box.setCurrentIndex(1)
             else:
+                logging.debug("not a standard organ name")
                 name_box = ROINameCleaningPrefixEntryField()
                 name_box.setEnabled(False)
 
@@ -386,6 +399,7 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
             name_box.setStyleSheet(self.stylesheet)
 
             if roi_name.lower() in self.organ_names_lowercase:
+                logging.debug("adding rows to tables organ")
                 # Add row to table
                 self.table_organ.insertRow(i)
                 self.table_organ.setRowHeight(i, 50)
@@ -396,6 +410,7 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
                 self.table_organ.setCellWidget(i, 3, rtss_combo_box)
                 continue
             else:
+                logging.debug("adding rows to tables volume")
                 # Add row to table
                 self.table_volume.insertRow(i)
                 self.table_volume.setRowHeight(i, 50)
@@ -405,12 +420,18 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
                 self.table_volume.setCellWidget(i, 2, name_box)
                 self.table_volume.setCellWidget(i, 3, rtss_combo_box)
             i += 1
+        
+        logging.debug("Completed for loop")
 
+        logging.debug("setting row height for organ table")
         # Set row height
         vertical_header_organ = self.table_organ.verticalHeader()
         vertical_header_organ.setSectionResizeMode(QtWidgets.QHeaderView.Fixed)
         vertical_header_organ.setDefaultSectionSize(40)
 
+        logging.debug("setting row height for volume table")
         vertical_header_volume = self.table_volume.verticalHeader()
         vertical_header_volume.setSectionResizeMode(QtWidgets.QHeaderView.Fixed)
         vertical_header_volume.setDefaultSectionSize(40)
+
+        logging.info("populate_table success")

--- a/src/View/batchprocessing/ROINameCleaningOptions.py
+++ b/src/View/batchprocessing/ROINameCleaningOptions.py
@@ -144,7 +144,6 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
         self.organ_names = []
         self.organ_names_lowercase = []
         self.volume_prefixes = []
-        self.volume_prefixes_lowercase = []
 
         self.get_standard_names()
         self.create_table_view()
@@ -169,7 +168,6 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
             header = next(f)  # Ignore the "header" of the column
             for row in csv_input:
                 self.volume_prefixes.append(row[1])
-                self.volume_prefixes_lowercase.append(row[1].lower())
             f.close()
 
     def create_table_view(self):

--- a/src/View/batchprocessing/ROINameCleaningOptions.py
+++ b/src/View/batchprocessing/ROINameCleaningOptions.py
@@ -39,10 +39,6 @@ class ROINameCleaningOrganComboBox(QtWidgets.QComboBox):
         roi_suggestions = self.roi_suggestions(roi_name,
                                                organ_names,
                                                volume_prefixes)
-        self.addItem(roi_suggestions[0][0])
-        self.addItem(roi_suggestions[1][0])
-        self.addItem(roi_suggestions[2][0])
-        self.insertSeparator(4)
 
         # Populate combo box options
         for organ in organ_names:
@@ -71,8 +67,7 @@ class ROINameCleaningOrganComboBox(QtWidgets.QComboBox):
         """
 
         roi_list = organ_names + volume_prefixes
-        suggestions = process.extract(roi_name, roi_list,
-                                      limit=3)  # will get the top 3 matches
+        suggestions = process.extractOne(roi_name, roi_list)  
 
         return suggestions
 

--- a/src/View/batchprocessing/ROINameCleaningOptions.py
+++ b/src/View/batchprocessing/ROINameCleaningOptions.py
@@ -1,5 +1,6 @@
 import csv
 import platform
+import logging
 from pydicom import dcmread
 from PySide6 import QtCore, QtWidgets
 from src.Controller.PathHandler import data_path, resource_path
@@ -176,7 +177,7 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
         Create a table to display all of the non-standard ROIs and
         options for what to do with them.
         """
-        logger.info("create_table_view_organ start")
+        logging.info("create_table_view_organ start")
         # Create table
         self.table_organ = QtWidgets.QTableWidget(self)
         self.table_organ.setStyleSheet(
@@ -213,14 +214,14 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
         # Add table to the main layout
         self.main_layout.addWidget(self.table_organ)
 
-        logger.info("create_table_view_organ success")
+        logging.info("create_table_view_organ success")
 
     def create_table_view_volume(self):
         """
         Create a table to display all of the non-standard ROIs and
         options for what to do with them.
         """
-        logger.info("create_table_view_volume start")
+        logging.info("create_table_view_volume start")
         # Create table
         self.table_volume = QtWidgets.QTableWidget(self)
         self.table_volume.setStyleSheet(
@@ -257,7 +258,7 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
         # Add table to the main layout
         self.main_layout.addWidget(self.table_volume)
 
-        logger.info("create_table_view_volume success")
+        logging.info("create_table_view_volume success")
 
     def populate_table(self, dicom_structure, batch_directory):
         """
@@ -267,7 +268,7 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
                                 patients loaded.
         :param batch_directory: The directory selected for batch processing.
         """
-        logger.info("populate_table start")
+        logging.info("populate_table start")
         # Update table column view organ
         roi_name_header = self.table_organ.horizontalHeader()
         roi_name_header.setSectionResizeMode(
@@ -350,7 +351,7 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
         # Loop through each ROI
         i = 0
         for roi_name in rois:
-            logger.debug("going through roi_name in rois")
+            logging.debug("going through roi_name in rois")
             # Create option combo box
             combo_box = ROINameCleaningOptionComboBox()
             combo_box.setStyleSheet(self.stylesheet)
@@ -359,12 +360,12 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
             # Get list of RTSTRUCTs
             dataset_list = rois[roi_name]
             if len(dataset_list) == 0:
-                logger.debug("creating dataset combo box")
+                logging.debug("creating dataset combo box")
                 continue
 
             # Remove common path from RTStructs
             for index in range(len(dataset_list)):
-                logger.debug("removing common path from RTStructs")
+                logging.debug("removing common path from RTStructs")
                 dataset_list[index] = \
                     dataset_list[index].replace(batch_directory, '')
 
@@ -375,13 +376,13 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
             # Generate organ combobox otherwise.
             if roi_name[0:3] in self.volume_prefixes \
                     or roi_name[0:4] in self.volume_prefixes:
-                logger.debug("if roi_name is volume prefix created text entry field")
+                logging.debug("if roi_name is volume prefix created text entry field")
                 name_box = ROINameCleaningPrefixEntryField()
                 name_box.setEnabled(False)
             elif roi_name.lower() in self.organ_names_lowercase:
             # Set default combo box entry to organ name in proper case
             # if the organ name is a standard one.
-                logger.debug("if the organ name is a standard one")
+                logging.debug("if the organ name is a standard one")
                 name_box = \
                 ROINameCleaningOrganComboBox(self.organ_names,
                                             self.volume_prefixes,
@@ -391,7 +392,7 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
                 name_box.setEnabled(True)
                 combo_box.setCurrentIndex(1)
             else:
-                logger.debug("not a standard organ name")
+                logging.debug("not a standard organ name")
                 name_box = ROINameCleaningPrefixEntryField()
                 name_box.setEnabled(False)
 
@@ -399,7 +400,7 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
             name_box.setStyleSheet(self.stylesheet)
 
             if roi_name.lower() in self.organ_names_lowercase:
-                logger.debug("adding rows to tables organ")
+                logging.debug("adding rows to tables organ")
                 # Add row to table
                 self.table_organ.insertRow(i)
                 self.table_organ.setRowHeight(i, 50)
@@ -410,7 +411,7 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
                 self.table_organ.setCellWidget(i, 3, rtss_combo_box)
                 continue
             else:
-                logger.debug("adding rows to tables volume")
+                logging.debug("adding rows to tables volume")
                 # Add row to table
                 self.table_volume.insertRow(i)
                 self.table_volume.setRowHeight(i, 50)
@@ -421,17 +422,17 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
                 self.table_volume.setCellWidget(i, 3, rtss_combo_box)
             i += 1
         
-        logger.debug("Completed for loop")
+        logging.debug("Completed for loop")
 
-        logger.debug("setting row height for organ table")
+        logging.debug("setting row height for organ table")
         # Set row height
         vertical_header_organ = self.table_organ.verticalHeader()
         vertical_header_organ.setSectionResizeMode(QtWidgets.QHeaderView.Fixed)
         vertical_header_organ.setDefaultSectionSize(40)
 
-        logger.debug("setting row height for volume table")
+        logging.debug("setting row height for volume table")
         vertical_header_volume = self.table_volume.verticalHeader()
         vertical_header_volume.setSectionResizeMode(QtWidgets.QHeaderView.Fixed)
         vertical_header_volume.setDefaultSectionSize(40)
 
-        logger.info("populate_table success")
+        logging.info("populate_table success")

--- a/src/View/batchprocessing/ROINameCleaningOptions.py
+++ b/src/View/batchprocessing/ROINameCleaningOptions.py
@@ -176,7 +176,7 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
         Create a table to display all of the non-standard ROIs and
         options for what to do with them.
         """
-        logging.info("create_table_view_organ start")
+        logger.info("create_table_view_organ start")
         # Create table
         self.table_organ = QtWidgets.QTableWidget(self)
         self.table_organ.setStyleSheet(
@@ -213,14 +213,14 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
         # Add table to the main layout
         self.main_layout.addWidget(self.table_organ)
 
-        logging.info("create_table_view_organ success")
+        logger.info("create_table_view_organ success")
 
     def create_table_view_volume(self):
         """
         Create a table to display all of the non-standard ROIs and
         options for what to do with them.
         """
-        logging.info("create_table_view_volume start")
+        logger.info("create_table_view_volume start")
         # Create table
         self.table_volume = QtWidgets.QTableWidget(self)
         self.table_volume.setStyleSheet(
@@ -257,7 +257,7 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
         # Add table to the main layout
         self.main_layout.addWidget(self.table_volume)
 
-        logging.info("create_table_view_volume success")
+        logger.info("create_table_view_volume success")
 
     def populate_table(self, dicom_structure, batch_directory):
         """
@@ -267,7 +267,7 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
                                 patients loaded.
         :param batch_directory: The directory selected for batch processing.
         """
-        logging.info("populate_table start")
+        logger.info("populate_table start")
         # Update table column view organ
         roi_name_header = self.table_organ.horizontalHeader()
         roi_name_header.setSectionResizeMode(
@@ -350,7 +350,7 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
         # Loop through each ROI
         i = 0
         for roi_name in rois:
-            logging.debug("going through roi_name in rois")
+            logger.debug("going through roi_name in rois")
             # Create option combo box
             combo_box = ROINameCleaningOptionComboBox()
             combo_box.setStyleSheet(self.stylesheet)
@@ -359,12 +359,12 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
             # Get list of RTSTRUCTs
             dataset_list = rois[roi_name]
             if len(dataset_list) == 0:
-                logging.debug("creating dataset combo box")
+                logger.debug("creating dataset combo box")
                 continue
 
             # Remove common path from RTStructs
             for index in range(len(dataset_list)):
-                logging.debug("removing common path from RTStructs")
+                logger.debug("removing common path from RTStructs")
                 dataset_list[index] = \
                     dataset_list[index].replace(batch_directory, '')
 
@@ -375,13 +375,13 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
             # Generate organ combobox otherwise.
             if roi_name[0:3] in self.volume_prefixes \
                     or roi_name[0:4] in self.volume_prefixes:
-                logging.debug("if roi_name is volume prefix created text entry field")
+                logger.debug("if roi_name is volume prefix created text entry field")
                 name_box = ROINameCleaningPrefixEntryField()
                 name_box.setEnabled(False)
             elif roi_name.lower() in self.organ_names_lowercase:
             # Set default combo box entry to organ name in proper case
             # if the organ name is a standard one.
-                logging.debug("if the organ name is a standard one")
+                logger.debug("if the organ name is a standard one")
                 name_box = \
                 ROINameCleaningOrganComboBox(self.organ_names,
                                             self.volume_prefixes,
@@ -391,7 +391,7 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
                 name_box.setEnabled(True)
                 combo_box.setCurrentIndex(1)
             else:
-                logging.debug("not a standard organ name")
+                logger.debug("not a standard organ name")
                 name_box = ROINameCleaningPrefixEntryField()
                 name_box.setEnabled(False)
 
@@ -399,7 +399,7 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
             name_box.setStyleSheet(self.stylesheet)
 
             if roi_name.lower() in self.organ_names_lowercase:
-                logging.debug("adding rows to tables organ")
+                logger.debug("adding rows to tables organ")
                 # Add row to table
                 self.table_organ.insertRow(i)
                 self.table_organ.setRowHeight(i, 50)
@@ -410,7 +410,7 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
                 self.table_organ.setCellWidget(i, 3, rtss_combo_box)
                 continue
             else:
-                logging.debug("adding rows to tables volume")
+                logger.debug("adding rows to tables volume")
                 # Add row to table
                 self.table_volume.insertRow(i)
                 self.table_volume.setRowHeight(i, 50)
@@ -421,17 +421,17 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
                 self.table_volume.setCellWidget(i, 3, rtss_combo_box)
             i += 1
         
-        logging.debug("Completed for loop")
+        logger.debug("Completed for loop")
 
-        logging.debug("setting row height for organ table")
+        logger.debug("setting row height for organ table")
         # Set row height
         vertical_header_organ = self.table_organ.verticalHeader()
         vertical_header_organ.setSectionResizeMode(QtWidgets.QHeaderView.Fixed)
         vertical_header_organ.setDefaultSectionSize(40)
 
-        logging.debug("setting row height for volume table")
+        logger.debug("setting row height for volume table")
         vertical_header_volume = self.table_volume.verticalHeader()
         vertical_header_volume.setSectionResizeMode(QtWidgets.QHeaderView.Fixed)
         vertical_header_volume.setDefaultSectionSize(40)
 
-        logging.info("populate_table success")
+        logger.info("populate_table success")

--- a/src/View/batchprocessing/ROINameCleaningOptions.py
+++ b/src/View/batchprocessing/ROINameCleaningOptions.py
@@ -59,15 +59,15 @@ class ROINameCleaningOrganComboBox(QtWidgets.QComboBox):
 
     def roi_suggestions(self, roi_name, organ_names, volume_prefixes):
         """
-        Get the top 3 suggestions for the selected ROI based on
+        Get the top suggestion for the selected ROI based on 
         string matching with standard ROIs provided in .csv format.
 
-        :return: two dimensional list with ROI name and string match percent
-        i.e [('MANDIBLE', 100), ('SUBMAND_L', 59), ('LIVER', 51)]
+        :return: two dimensional tuple with ROI name and string match percent
+        i.e [('PROSTATE', 100)]
         """
 
         roi_list = organ_names + volume_prefixes
-        suggestions = process.extractOne(roi_name, roi_list)  
+        suggestions = process.extractOne(roi_name, roi_list)
 
         return suggestions
 

--- a/src/View/batchprocessing/ROINameCleaningOptions.py
+++ b/src/View/batchprocessing/ROINameCleaningOptions.py
@@ -367,20 +367,20 @@ class ROINameCleaningOptions(QtWidgets.QWidget):
                     or roi_name[0:4] in self.volume_prefixes:
                 name_box = ROINameCleaningPrefixEntryField()
                 name_box.setEnabled(False)
-            else:
+            elif roi_name.lower() in self.organ_names_lowercase:
+            # Set default combo box entry to organ name in proper case
+            # if the organ name is a standard one.
                 name_box = \
-                    ROINameCleaningOrganComboBox(self.organ_names,
-                                                self.volume_prefixes,
-                                                roi_name)
-                # Set default combo box entry to organ name in proper case
-                # if the organ name is a standard one.
-                if roi_name.lower() in self.organ_names_lowercase:
-                    index = self.organ_names_lowercase.index(roi_name.lower())
-                    name_box.setCurrentIndex(index)
-                    name_box.setEnabled(True)
-                    combo_box.setCurrentIndex(1)
-                else:
-                    name_box.setEnabled(False)
+                ROINameCleaningOrganComboBox(self.organ_names,
+                                            self.volume_prefixes,
+                                            roi_name)
+                index = self.organ_names_lowercase.index(roi_name.lower())
+                name_box.setCurrentIndex(index)
+                name_box.setEnabled(True)
+                combo_box.setCurrentIndex(1)
+            else:
+                name_box = ROINameCleaningPrefixEntryField()
+                name_box.setEnabled(False)
 
             combo_box.currentIndexChanged.connect(name_box.change_enabled)
             name_box.setStyleSheet(self.stylesheet)


### PR DESCRIPTION
Changes made here are in regards to ROINameCleaningOptions.py in src/View/batchprocessing/ where the requirement was to separate anatomy changes from GTV/CTV/PTV through the GUI by either different tabs or different tables. 

There was an issue where the wrong item would be suggested when changing ROI files, this has been changed but needs to be tested with more DICOM files before I can say it is fixed. But with what I have currently, it seems to run perfectly.

The choice was made that it would be displayed as two tables within the same tab so that when the tab is ticked it will run through the whole section. So if any of the ROIs need changing or don't need changing they will be considered together and changed together. With this choice there had to be double-ups in order to display both tables together, so whenever the organ_table would be made so will the volume_table to make sure they are being initialized the same way. 

Reviews and advice are welcome.