### PR TITLE
Draw ROI Transparency Slider #2351

### DIFF
--- a/src/View/mainpage/DrawROIWindow/Drawing.py
+++ b/src/View/mainpage/DrawROIWindow/Drawing.py
@@ -185,6 +185,7 @@ class Drawing(QtWidgets.QGraphicsScene):
         Convert QImage containing modified CT slice with highlighted pixels
         into a QPixmap, and then display it onto the view.
         """
+        self.removeItem(self.q_pixmaps)
         self.q_pixmaps = QtWidgets.QGraphicsPixmapItem(
             QtGui.QPixmap.fromImage(self.q_image))
         self.addItem(self.q_pixmaps)

--- a/src/View/mainpage/DrawROIWindow/Drawing.py
+++ b/src/View/mainpage/DrawROIWindow/Drawing.py
@@ -118,9 +118,7 @@ class Drawing(QtWidgets.QGraphicsScene):
                 self.according_color_dict[(x_coord, y_coord)] = colors
 
             points = get_pixel_coords(self.according_color_dict, self.rows, self.cols)
-
             self._set_color_of_pixels(points)
-
             self.refresh_image()
 
     def _set_color_of_pixels(self, points):

--- a/src/View/mainpage/DrawROIWindow/Drawing.py
+++ b/src/View/mainpage/DrawROIWindow/Drawing.py
@@ -1,6 +1,6 @@
 import math
-
 import numpy
+import logging
 from PySide6 import QtCore, QtGui, QtWidgets
 from PySide6.QtGui import QColor, QPen
 from PySide6.QtWidgets import QGraphicsPixmapItem, QGraphicsEllipseItem
@@ -104,9 +104,9 @@ class Drawing(QtWidgets.QGraphicsScene):
                         self.target_pixel_coords.add((x_coord, y_coord))
 
             """For the meantime, a new image is created and the pixels 
-            specified are coloured. This will need to altered so that it 
-            creates a new layer over the existing image instead of replacing 
-            it. """
+            specified are coloured. The _set_colour_of_pixels function
+             is then called to colour the newly drawn pixels and blend in
+             transparency."""
             # Convert QPixMap into Qimage
             for x_coord, y_coord in self.target_pixel_coords:
                 temp = set()
@@ -130,9 +130,11 @@ class Drawing(QtWidgets.QGraphicsScene):
 
         :param points:  Set of x and y co-ordinates of pixels to be coloured
         """
+        logging.debug("_set_color_of_pixels started")
         img = self.img.toImage()
         for x_coord, y_coord in points:
             old_color = img.pixelColor(x_coord, y_coord)
+            # Blend the individual RGB values of the original pixel with the drawn ROI colour values
             new_color = QtGui.QColor(self.drawn_pixel_color.red() * (1 - self.pixel_transparency)
                                      + old_color.red() * self.pixel_transparency,
                                      self.drawn_pixel_color.blue() * (1 - self.pixel_transparency)
@@ -141,14 +143,17 @@ class Drawing(QtWidgets.QGraphicsScene):
                                      + old_color.green() * self.pixel_transparency,
                                      255)
             self.q_image.setPixelColor(x_coord, y_coord, new_color)
+        logging.debug("_set_color_of_pixels finished")
 
     def update_pixel_transparency(self):
         """
         Updates the transparency of pixels that have already been drawn, with new
         transparency value set by user and refreshes the image.
         """
+        logging.debug("update_pixel_transparency started")
         self._set_color_of_pixels(get_pixel_coords(self.target_pixel_coords, self.rows, self.cols))
         self.refresh_image()
+        logging.debug("update_pixel_transparency finished")
 
     def _find_neighbor_point(self, event):
         """

--- a/src/View/mainpage/DrawROIWindow/UIDrawROIWindow.py
+++ b/src/View/mainpage/DrawROIWindow/UIDrawROIWindow.py
@@ -672,7 +672,7 @@ class UIDrawROIWindow:
                 and self.drawingROI.current_slice == self.current_slice:
             self.dicom_view.view.setScene(self.drawingROI)
         self.draw_roi_window_viewport_zoom_input. \
-            setText("{:.0f}".format(self.dicom_view.zoom * 100) + "%")
+            setText("{:.2f}".format(self.dicom_view.zoom * 100) + "%")
         self.draw_roi_window_viewport_zoom_input.setCursorPosition(0)
 
     def transparency_slider_value_changed(self):

--- a/src/View/mainpage/DrawROIWindow/UIDrawROIWindow.py
+++ b/src/View/mainpage/DrawROIWindow/UIDrawROIWindow.py
@@ -6,7 +6,7 @@ from PySide6.QtCore import Qt, QSize, QRegularExpression
 from PySide6.QtGui import QIcon, QPixmap, QRegularExpressionValidator
 from PySide6.QtWidgets import QFormLayout, QLabel, QLineEdit, \
     QSizePolicy, QHBoxLayout, QPushButton, QWidget, \
-    QMessageBox, QComboBox
+    QMessageBox, QComboBox, QSlider
 
 from src.Controller.MainPageController import MainPageCallClass
 from src.Controller.PathHandler import resource_path
@@ -56,6 +56,7 @@ class UIDrawROIWindow:
         self.colour = None
         self.ds = None
         self.zoom = 1.0
+        self.pixel_transparency = 0.50
 
         self.upper_limit = None
         self.lower_limit = None
@@ -119,6 +120,8 @@ class UIDrawROIWindow:
             _translate("MaxPixelDensityLabel", "Maximum density (pixels): "))
         self.max_pixel_density_line_edit.setText(
             _translate("MaxPixelDensityInput", ""))
+        self.transparency_slider_label.setText(
+            _translate("TransparencySliderLabel", "Transparency:"))
         self.toggle_keep_empty_pixel_label.setText(
             _translate("ToggleKeepEmptyPixelLabel", "Keep empty pixel: "))
 
@@ -294,6 +297,39 @@ class UIDrawROIWindow:
             addRow(self.draw_roi_window_viewport_zoom_box)
 
         self.init_cursor_radius_change_box()
+
+        # Create slider to adjust the transparency of drawn pixels
+        self.transparency_slider_box = QHBoxLayout()
+        self.transparency_slider_label = QLabel()
+        self.transparency_slider_label.setObjectName("TransparencySliderLabel")
+
+        self.transparency_slider_input_box = QLineEdit()
+        self.transparency_slider_input_box.setObjectName("TransparencySliderInputBox")
+        self.transparency_slider_input_box.setText("{:.0f}".format(self.pixel_transparency * 100) + "%")
+        self.transparency_slider_input_box.setCursorPosition(0)
+        self.transparency_slider_input_box.setEnabled(False)
+        self.transparency_slider_input_box.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Minimum)
+        self.transparency_slider_input_box.resize(self.transparency_slider_input_box.sizeHint().width(),
+                                                  self.transparency_slider_input_box.sizeHint().height())
+
+        self.transparency_slider = QSlider(Qt.Horizontal)
+        self.transparency_slider.setMinimum(0)
+        self.transparency_slider.setMaximum(100)
+        self.transparency_slider.setSingleStep(1)
+        self.transparency_slider.setTickPosition(QSlider.TicksBothSides)
+        self.transparency_slider.setTickInterval(10)
+        self.transparency_slider.setValue(50)
+        self.transparency_slider.setObjectName("TransparencySlider")
+        self.transparency_slider.resize(self.transparency_slider.sizeHint().width(),
+                                        self.transparency_slider.sizeHint().height())
+        self.transparency_slider.valueChanged.connect(self.transparency_slider_value_changed)
+
+        self.transparency_slider_box.addWidget(self.transparency_slider_label)
+        self.transparency_slider_box.addWidget(self.transparency_slider_input_box)
+        self.transparency_slider_box.addWidget(self.transparency_slider)
+        self.draw_roi_window_input_container_box.addRow(self.transparency_slider_box)
+
+
         # Create field to toggle two options: Keep empty pixel or fill empty
         # pixel when using draw cursor
         self.toggle_keep_empty_pixel_box = QHBoxLayout()
@@ -636,8 +672,16 @@ class UIDrawROIWindow:
                 and self.drawingROI.current_slice == self.current_slice:
             self.dicom_view.view.setScene(self.drawingROI)
         self.draw_roi_window_viewport_zoom_input. \
-            setText("{:.2f}".format(self.dicom_view.zoom * 100) + "%")
+            setText("{:.0f}".format(self.dicom_view.zoom * 100) + "%")
         self.draw_roi_window_viewport_zoom_input.setCursorPosition(0)
+
+    def transparency_slider_value_changed(self):
+        self.pixel_transparency = round(self.transparency_slider.value() / 100.0, 2)
+        self.transparency_slider_input_box.setText("{:.0f}".format(self.pixel_transparency * 100) + "%")
+        self.transparency_slider_input_box.setCursorPosition(0)
+        if hasattr(self, 'drawingROI') and self.drawingROI:
+            self.drawingROI.pixel_transparency = self.pixel_transparency
+            self.drawingROI.update_pixel_transparency()
 
     def toggle_keep_empty_pixel_box_index_changed(self):
         self.keep_empty_pixel = self.toggle_keep_empty_pixel_combo_box. \
@@ -818,8 +862,8 @@ class UIDrawROIWindow:
                     self.current_slice,
                     self.drawing_tool_radius,
                     self.keep_empty_pixel,
+                    self.pixel_transparency,
                     set()
-
                 )
                 self.slice_changed = True
                 self.dicom_view.view.setScene(self.drawingROI)

--- a/src/View/mainpage/DrawROIWindow/UIDrawROIWindow.py
+++ b/src/View/mainpage/DrawROIWindow/UIDrawROIWindow.py
@@ -329,7 +329,6 @@ class UIDrawROIWindow:
         self.transparency_slider_box.addWidget(self.transparency_slider)
         self.draw_roi_window_input_container_box.addRow(self.transparency_slider_box)
 
-
         # Create field to toggle two options: Keep empty pixel or fill empty
         # pixel when using draw cursor
         self.toggle_keep_empty_pixel_box = QHBoxLayout()

--- a/test/test_view_drawing.py
+++ b/test/test_view_drawing.py
@@ -1,0 +1,95 @@
+import os
+import pytest
+from pathlib import Path
+from pydicom import dcmread
+from pydicom.errors import InvalidDicomError
+from src.Controller.GUIController import MainWindow
+from src.Controller.ROIOptionsController import RoiDrawOptions
+from src.Model import ImageLoading
+from src.Model.PatientDictContainer import PatientDictContainer
+
+
+def find_DICOM_files(file_path):
+    """Function to find DICOM files in a given folder.
+    :param file_path: File path of folder to search.
+    :return: List of file paths of DICOM files in given folder.
+    """
+    dicom_files = []
+
+    # Walk through directory
+    for root, dirs, files in os.walk(file_path, topdown=True):
+        for name in files:
+            # Attempt to open file as a DICOM file
+            try:
+                dcmread(os.path.join(root, name))
+            except (InvalidDicomError, FileNotFoundError):
+                pass
+            else:
+                dicom_files.append(os.path.join(root, name))
+    return dicom_files
+
+
+class TestDrawingMock:
+    """Function to set up a Drawing window."""
+    __test__ = False
+
+    def __init__(self):
+        # Load test DICOM files
+        desired_path = Path.cwd().joinpath('test', 'testdata')
+        selected_files = find_DICOM_files(desired_path)  # list of DICOM test files
+        file_path = os.path.dirname(os.path.commonprefix(selected_files))  # file path of DICOM files
+        read_data_dict, file_names_dict = ImageLoading.get_datasets(selected_files)
+
+        # Create patient dict container object
+        patient_dict_container = PatientDictContainer()
+        patient_dict_container.clear()
+        patient_dict_container.set_initial_values(file_path, read_data_dict, file_names_dict)
+
+        # Set additional attributes in patient dict container (otherwise program will crash and test will fail)
+        if "rtss" in file_names_dict:
+            dataset_rtss = dcmread(file_names_dict['rtss'])
+            self.rois = ImageLoading.get_roi_info(dataset_rtss)
+            dict_raw_contour_data, dict_numpoints = ImageLoading.get_raw_contour_data(dataset_rtss)
+            dict_pixluts = ImageLoading.get_pixluts(read_data_dict)
+
+            patient_dict_container.set("rois", self.rois)
+            patient_dict_container.set("raw_contour", dict_raw_contour_data)
+            patient_dict_container.set("num_points", dict_numpoints)
+            patient_dict_container.set("pixluts", dict_pixluts)
+
+        # main window
+        self.main_window = MainWindow()
+
+        rois = patient_dict_container.get("rois")
+        dataset_rtss = patient_dict_container.get("dataset_rtss")
+
+        self.draw_window = RoiDrawOptions(rois, dataset_rtss)
+
+
+@pytest.fixture(scope="module")
+def test_object():
+    """Function to initialise a Drawing window object."""
+    test = TestDrawingMock()
+    return test
+
+
+def test_change_transparency_slider_value(qtbot, test_object, init_config):
+    """Function to change the value of the transparency slider, and assert that the image has been updated."""
+    # Assert Drawing window exists
+    test_object.draw_window.show()
+    assert test_object.draw_window.windowTitle() == "OnkoDICOM - Draw Region Of Interest"
+
+    # Assert initial drawing has been created
+    test_object.draw_window.min_pixel_density_line_edit.setText("900")
+    test_object.draw_window.max_pixel_density_line_edit.setText("1000")
+    test_object.draw_window.onDrawClicked()
+    post_draw_clicked_drawing = test_object.draw_window.drawingROI.q_pixmaps
+    assert post_draw_clicked_drawing is not None
+
+    # Assert drawn image has been changed after slider adjustment
+    test_object.draw_window.transparency_slider.setValue(100)
+    post_transparency_change_drawing = test_object.draw_window.drawingROI.q_pixmaps
+    assert post_transparency_change_drawing != post_draw_clicked_drawing
+
+    # Run Drawing reset, prevents post test crash
+    test_object.draw_window.onResetClicked()


### PR DESCRIPTION
- Added a transparency slider to allow the drawn pixels in the draw ROI window to be adjust to allow users to see the original image pixels underneath what they have drawn. 
- Reworked how the existing draw functions coloured pixels to all use the same function that draws the pixels transparently. 
- Added a test to check that the transparency slider does change the pixels viewed by the user.