### PR TITLE
Removes the first column in the clinical-data-SR rather then hardcoding a column name

### DIFF
--- a/src/View/batchprocessing/SelectSubgroupOptions.py
+++ b/src/View/batchprocessing/SelectSubgroupOptions.py
@@ -79,8 +79,10 @@ class SelectSubgroupOptions(QtWidgets.QWidget):
         self.filter_table.setRowCount(0)
         self.filter_table.setColumnCount(0)
 
+        # removes the Patient Identifier (assumed to be first column
+        # in the dataset)
         # not a necessary filter option as specified in requirements
-        options_data_dict.pop("HASHidentifier")
+        options_data_dict.pop(list(options_data_dict)[0])
 
         columns_to_remove = []
 

--- a/src/View/batchprocessing/SelectSubgroupOptions.py
+++ b/src/View/batchprocessing/SelectSubgroupOptions.py
@@ -80,7 +80,9 @@ class SelectSubgroupOptions(QtWidgets.QWidget):
         self.filter_table.setColumnCount(0)
 
         # removes the Patient Identifier (assumed to be first column
-        # in the dataset)
+        # in the dataset) 
+        # As the column name may be changing we cannot hard code the 
+        # column name
         # not a necessary filter option as specified in requirements
         options_data_dict.pop(list(options_data_dict)[0])
 


### PR DESCRIPTION
Assuming the first column in the clinical data is the Patient Identifier this will be removed from what is displayed in the filtering options table regardless of its name. 