### PR TITLE
Select ROI GUI refactor

### DIFF
--- a/src/Controller/ROIOptionsController.py
+++ b/src/Controller/ROIOptionsController.py
@@ -1,6 +1,7 @@
+import logging
+
 from src.View.ImageFusion.UITransferROIWindow import UITransferROIWindow
 from src.View.mainpage.DeleteROIWindow import *
-from src.View.mainpage.DrawROIWindow.SelectROIPopUp import SelectROIPopUp
 from src.View.mainpage.DrawROIWindow.UIDrawROIWindow import UIDrawROIWindow
 from src.View.mainpage.ManipulateROIWindow import *
 
@@ -71,13 +72,11 @@ class ROIDrawOption:
         super(ROIDrawOption, self).__init__()
         self.structure_modified_function = structure_modified_function
 
-    def show_roi_draw_options(self):
-        self.choose_roi_name_window = SelectROIPopUp()
-        self.choose_roi_name_window.signal_roi_name.connect(
-            self.roi_name_selected)
-        self.choose_roi_name_window.show()
-
-    def roi_name_selected(self, roi_name):
+    def show_roi_draw_window(self):
+        """
+        Gets data needed for the draw ROI window, creates it and displays the popup window
+        """
+        logging.debug("show_roi_draw_window started")
         patient_dict_container = PatientDictContainer()
         rois = patient_dict_container.get("rois")
         dataset_rtss = patient_dict_container.get("dataset_rtss")
@@ -89,7 +88,6 @@ class ROIDrawOption:
         else:
             self.draw_window.update_ui(rois, dataset_rtss)
 
-        self.draw_window.set_selected_roi_name(roi_name)
         self.draw_window.show()
 
 
@@ -172,6 +170,7 @@ class ROITransferOption:
         The class that will be called by ImageFusion to access the ROI
         Transfer controller
         """
+
     def __init__(self, fixed_dict_structure_modified_function,
                  moving_dict_structure_modified_function):
         """
@@ -197,9 +196,9 @@ class ROITransferOption:
         """
         self.roi_transfer_option_pop_up_window = ROITransferOptionUI()
         self.roi_transfer_option_pop_up_window. \
-            signal_roi_transferred_to_moving_container\
+            signal_roi_transferred_to_moving_container \
             .connect(self.moving_dict_structure_modified_function)
         self.roi_transfer_option_pop_up_window. \
-            signal_roi_transferred_to_fixed_container\
+            signal_roi_transferred_to_fixed_container \
             .connect(self.fixed_dict_structure_modified_function)
         self.roi_transfer_option_pop_up_window.show()

--- a/src/View/mainpage/DrawROIWindow/SelectROIPopUp.py
+++ b/src/View/mainpage/DrawROIWindow/SelectROIPopUp.py
@@ -44,13 +44,13 @@ class SelectROIPopUp(QDialog):
         self.button_area = QWidget()
         self.cancel_button = QPushButton("Cancel")
         self.cancel_button.clicked.connect(self.on_cancel_clicked)
-        self.begin_draw_button = QPushButton("Begin Draw Process")
+        self.select_roi_button = QPushButton("Select ROI")
 
-        self.begin_draw_button.clicked.connect(self.on_begin_clicked)
+        self.select_roi_button.clicked.connect(self.on_select_roi_clicked)
 
         self.button_layout = QHBoxLayout()
         self.button_layout.addWidget(self.cancel_button)
-        self.button_layout.addWidget(self.begin_draw_button)
+        self.button_layout.addWidget(self.select_roi_button)
         self.button_area.setLayout(self.button_layout)
 
         self.list_label = QLabel()
@@ -111,10 +111,10 @@ class SelectROIPopUp(QDialog):
         """
         function triggered when an ROI is clicked
         """
-        self.begin_draw_button.setEnabled(True)
-        self.begin_draw_button.setFocus()
+        self.select_roi_button.setEnabled(True)
+        self.select_roi_button.setFocus()
 
-    def on_begin_clicked(self):
+    def on_select_roi_clicked(self):
         """
         function to start the draw ROI function
         """

--- a/src/View/mainpage/StructureTab.py
+++ b/src/View/mainpage/StructureTab.py
@@ -239,7 +239,7 @@ class StructureTab(QtWidgets.QWidget):
         self.roi_delete_handler.show_roi_delete_options()
 
     def roi_draw_clicked(self):
-        self.roi_draw_handler.show_roi_draw_options()
+        self.roi_draw_handler.show_roi_draw_window()
 
     def roi_manipulate_clicked(self):
         """ Open ROI Manipulate Window """


### PR DESCRIPTION
In order to place the draw ROI window inside of the main Onko window, we must first move the step that allows the user to select an ROI.

This will instead be placed under a button on the draw ROI window, which will then trigger the original select ROI popup.

Logging has been introduced for newly added/modified methods.

No testing is present on this branch as no changes have been fundamentally made to the select ROI functionality. One thing that could be tested is the saving restriction, where the user must select an ROI type before saving. However, this is trivial within QT due to the use of popup messages/screens.