### PR TITLE
Fixed draw ROI issue when manaully drawing pixels with cursor

### DIFF
--- a/src/View/mainpage/DrawROIWindow/Drawing.py
+++ b/src/View/mainpage/DrawROIWindow/Drawing.py
@@ -389,7 +389,7 @@ class Drawing(QtWidgets.QGraphicsScene):
         """
         Uses the users mouse click position to set the fill source
         """
-        self.fill_source = [event.scenePos().x(), event.scenePos().y()]
+        self.fill_source = [round(event.scenePos().x()), round(event.scenePos().y())]
         self._display_pixel_color()
 
     def manual_draw_roi(self, event):


### PR DESCRIPTION
Fixed draw ROI issue when manually drawing pixels with cursor.

This was due to the BFS source point being set as some form of float, causing the rest of the comparative array (which is used to determine if a pixel is coloured) to all be floats as well.