### PR TITLE
Added null check for dataset in patient_dict_container

### DIFF
--- a/src/Model/batchprocessing/BatchProcessClinicalDataSR2CSV.py
+++ b/src/Model/batchprocessing/BatchProcessClinicalDataSR2CSV.py
@@ -94,6 +94,9 @@ class BatchProcessClinicalDataSR2CSV(BatchProcess):
         """
         datasets = self.patient_dict_container.dataset
 
+        if not datasets:
+            return None
+
         for ds in datasets:
             # Check for SR files
             if datasets[ds].SOPClassUID == '1.2.840.10008.5.1.4.1.1.88.33':


### PR DESCRIPTION
Added a null check so the application does not crash for this BatchProcess when no SR files are found but rather behaves correctly and lets the user know that no files were found.