### PR TITLE
Separated Fill and Draw Functionalities into Their Own Buttons #2444

### DIFF
--- a/src/View/mainpage/DrawROIWindow/Drawing.py
+++ b/src/View/mainpage/DrawROIWindow/Drawing.py
@@ -4,6 +4,7 @@ import logging
 from PySide6 import QtCore, QtGui, QtWidgets
 from PySide6.QtGui import QColor, QPen
 from PySide6.QtWidgets import QGraphicsPixmapItem, QGraphicsEllipseItem
+from PySide6.QtCore import Slot
 
 from src.constants import DEFAULT_WINDOW_SIZE
 from src.Model.Transform import linear_transform, get_pixel_coords, \
@@ -65,6 +66,7 @@ class Drawing(QtWidgets.QGraphicsScene):
         self.max_bounds_x = self.rows
         self.max_bounds_y = self.cols
         self.fill_source = None
+        self.is_drawing = False
 
     def set_bounds(self):
         """
@@ -392,6 +394,15 @@ class Drawing(QtWidgets.QGraphicsScene):
         self.fill_source = [round(event.scenePos().x()), round(event.scenePos().y())]
         self._display_pixel_color()
 
+    @Slot(bool)
+    def set_is_drawing(self, is_drawing):
+        """
+        Function triggered when either the Draw or Fill button is pressed from the menu.
+        Sets the is_drawing bool, allows for filling or drawing from separate button presses
+        """
+        logging.debug("set_is_drawing started")
+        self.is_drawing = is_drawing
+
     def manual_draw_roi(self, event):
         """
         Draws the ROI based on the users mouse press event and position
@@ -425,7 +436,7 @@ class Drawing(QtWidgets.QGraphicsScene):
             This method is called to handle a mouse press event
             :param event: the mouse event
         """
-        if self.fill_source is None:
+        if not self.is_drawing:
             self.set_source(event)
         else:
             self.manual_draw_roi(event)

--- a/test/test_view_drawing.py
+++ b/test/test_view_drawing.py
@@ -112,7 +112,7 @@ def test_change_transparency_slider_value(qtbot, test_object, init_config):
     # Assert initial drawing has been created
     draw_roi_window.min_pixel_density_line_edit.setText("900")
     draw_roi_window.max_pixel_density_line_edit.setText("1000")
-    draw_roi_window.onDrawClicked()
+    draw_roi_window.onFillClicked()
     draw_roi_window.drawingROI.fill_source = [250, 250]
     draw_roi_window.drawingROI._display_pixel_color()
     post_draw_clicked_drawing = draw_roi_window.drawingROI.q_pixmaps
@@ -122,6 +122,25 @@ def test_change_transparency_slider_value(qtbot, test_object, init_config):
     draw_roi_window.transparency_slider.setValue(100)
     post_transparency_change_drawing = draw_roi_window.drawingROI.q_pixmaps
     assert post_transparency_change_drawing != post_draw_clicked_drawing
+
+    # Run Drawing reset, prevents post test crash
+    draw_roi_window.onResetClicked()
+
+
+def test_manual_drawing(qtbot, test_object, init_config):
+    """Function to create a drawing, press fill, press draw, and assert that the drawing is in draw "mode"."""
+    # Triggering draw window
+    qtbot.mouseClick(test_object.main_window.structures_tab.button_roi_draw, Qt.LeftButton)
+    assert test_object.main_window.draw_roi is not None
+    draw_roi_window = test_object.main_window.draw_roi
+
+    # Assert drawing is in draw "mode"
+    draw_roi_window.min_pixel_density_line_edit.setText("900")
+    draw_roi_window.max_pixel_density_line_edit.setText("1000")
+    qtbot.mouseClick(draw_roi_window.image_slice_number_fill_button, Qt.LeftButton)
+    qtbot.mouseClick(draw_roi_window.image_slice_number_draw_button, Qt.LeftButton)
+    assert draw_roi_window.keep_empty_pixel is True
+    assert draw_roi_window.drawingROI.is_drawing is True
 
     # Run Drawing reset, prevents post test crash
     draw_roi_window.onResetClicked()


### PR DESCRIPTION
- Added a fill button, linked to fill functionality (practically renamed from the old draw)
- Moved draw button, linked to drawing functionality
- Fixed the bug of not being able to fill more than once 