### PR TITLE
Windowing draw roi #2452

### DIFF
--- a/src/View/mainpage/DrawROIWindow/Drawing.py
+++ b/src/View/mainpage/DrawROIWindow/Drawing.py
@@ -179,6 +179,19 @@ class Drawing(QtWidgets.QGraphicsScene):
                     return True
         return False
 
+    def update_dicom_image(self):
+        """
+        Updates the dicom image data, recalculating the roi pixel colour and displaying changes
+        """
+        logging.debug("update_dicom_image started for slice %s", self.current_slice)
+
+        self.q_image = self.img.toImage()
+
+        points = get_pixel_coords(self.according_color_dict, self.rows, self.cols)
+        self._set_color_of_pixels(points)
+
+        self.refresh_image()
+
     def getValues(self):
         """
         This function gets the corresponding values of all the points in the

--- a/src/View/mainpage/DrawROIWindow/UIDrawROIWindow.py
+++ b/src/View/mainpage/DrawROIWindow/UIDrawROIWindow.py
@@ -644,6 +644,26 @@ class UIDrawROIWindow:
             self.ds = None
             self.has_drawing = False
 
+    def update_draw_roi_pixmaps(self):
+        """
+        Updates the pixmaps_axial data for the displayed DICOM draw roi panel.
+        This will update all slices that do not have a drawn ROI, as well as looping through the drawn objects and
+        updating the ROI image
+        """
+        logging.debug("update_draw_roi_pixmaps started")
+        self.save_drawing_progress(self.current_slice)
+        self.dicom_view.update_view()
+
+        # for each drawn ROI slice
+        for slice_number in self.drawn_roi_list:
+            if self.drawn_roi_list.get(slice_number)['drawingROI'] is not None:
+                slice_drawing_roi = self.drawn_roi_list[slice_number]['drawingROI']
+                slice_drawing_roi.img = self.patient_dict_container.get("pixmaps_axial")[slice_number]
+                slice_drawing_roi.update_dicom_image()
+
+        if hasattr(self, 'drawingROI') and self.drawingROI:
+            self.dicom_view.view.setScene(self.drawingROI)
+
     def onZoomInClicked(self):
         """
         This function is used for zooming in button

--- a/src/View/mainpage/MainPage.py
+++ b/src/View/mainpage/MainPage.py
@@ -279,6 +279,10 @@ class UIMainWindow:
                 self.image_fusion_view_coronal.update_view()
                 self.image_fusion_view_sagittal.update_view()
 
+        if hasattr(self, 'draw_roi'):
+            if self.draw_roi is not None:
+                self.draw_roi.update_draw_roi_pixmaps()
+
     def toggle_cut_lines(self):
         if self.dicom_axial_view.horizontal_view is None or \
                 self.dicom_axial_view.vertical_view is None or \
@@ -529,9 +533,6 @@ class UIMainWindow:
         """Called to disable toolbar options when they do not apply / cannot be used in the current draw roi context"""
         self.action_handler.action_save_structure.setDisabled(disabled)
         self.action_handler.action_save_as_anonymous.setDisabled(disabled)
-
-        self.action_handler.menu_windowing.setDisabled(disabled)
-        self.action_handler.windowing_window.setDisabled(disabled)
 
         self.action_handler.action_one_view.setDisabled(disabled)
         self.action_handler.action_four_views.setDisabled(disabled)

--- a/test/test_view_drawing.py
+++ b/test/test_view_drawing.py
@@ -80,8 +80,6 @@ def test_draw_roi_window_displayed(qtbot, test_object):
 
     menu_items = [test_object.main_window.action_handler.action_save_structure,
                   test_object.main_window.action_handler.action_save_as_anonymous,
-                  test_object.main_window.action_handler.menu_windowing,
-                  test_object.main_window.action_handler.windowing_window,
                   test_object.main_window.action_handler.action_one_view,
                   test_object.main_window.action_handler.action_four_views,
                   test_object.main_window.action_handler.action_show_cut_lines,
@@ -141,3 +139,31 @@ def test_manual_drawing(qtbot, test_object, init_config):
 
     # Run Drawing reset, prevents post test crash
     draw_roi_window.onResetClicked()
+
+
+def test_roi_windowing(qtbot, test_object):
+    """Tests that the windowing action items changes the draw ROI windowing display"""
+    qtbot.mouseClick(test_object.main_window.structures_tab.button_roi_draw, Qt.LeftButton)
+    assert test_object.main_window.draw_roi is not None
+    draw_roi_window = test_object.main_window.draw_roi
+
+    existing_window = draw_roi_window.patient_dict_container.get("window")
+    existing_level = draw_roi_window.patient_dict_container.get("level")
+    existing_pixmaps = draw_roi_window.patient_dict_container.get("pixmaps_axial")
+    existing_view = draw_roi_window.dicom_view.scene
+
+    # changing windowing type directly via handler
+    test_object.main_window.action_handler.windowing_handler(None, "Lung")
+
+    new_window = draw_roi_window.patient_dict_container.get("window")
+    new_level = draw_roi_window.patient_dict_container.get("level")
+    new_pixmaps = draw_roi_window.patient_dict_container.get("pixmaps_axial")
+    new_view = draw_roi_window.dicom_view.scene
+
+    # assert that the values have been updated
+    assert existing_window != new_window
+    assert existing_level != new_level
+    assert existing_pixmaps != new_pixmaps
+    assert existing_view != new_view
+
+    assert draw_roi_window.dicom_view.label_wl.text() == f"W/L: {str(new_window)}/{str(new_level)}"


### PR DESCRIPTION
Implemented windowing option for draw ROI page. This allows the user to change the windowing type whilst drawing a new ROI without loosing their progress.