### PR TITLE
Fixes and workarounds needed to get 0.05.02-beta running on Ubuntu 20.04

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "onkodicom"
-version = "0.1.0"
+version = "0.5.2"
 description = ""
 authors = ["Ashley Maher <ashley.maher@didymodesigns.com.au>"]
 license = "LGPL"
@@ -32,7 +32,7 @@ pyside6 = { version = "6.2.0"}  # groups = ["user", "dev"]
 vtk = { version = "*"}  # groups = ["user", "dev"] 
 shapely = ">=1.8.1"  # groups = ["user", "dev"]
 python-Levenshtein = { version = "*"}  # groups = ["user", "dev"]
-opencv-python = { version = "<=4.5.3.56"}  # groups = ["user", "dev"]
+opencv-python = { version = "*"}  # groups = ["user", "dev"]
 matplotlib = { version = "*"}  # groups = ["user", "dev"]
 pyradiomics = { version = "*"}  # groups = ["user", "dev"]
 sklearn = { version = "*"}  # groups = ["user", "dev"]

--- a/src/Controller/MainPageController.py
+++ b/src/Controller/MainPageController.py
@@ -1,6 +1,7 @@
 # This file handles all the processes within the Main page window of the
 # software
 import csv
+import logging
 import math
 
 import matplotlib.cbook
@@ -10,7 +11,12 @@ from dateutil.relativedelta import relativedelta
 from matplotlib.backend_bases import MouseEvent
 
 import src.constants as constant
-from src.Model.Anon import anonymize
+try:
+    from src.Model.Anon import anonymize
+except ImportError as ePymedphysImportFailed:
+    FEATURE_TOGGLE_PSEUDONYMISE = False
+    logging.error(ePymedphysImportFailed)
+    
 from src.Model.PatientDictContainer import PatientDictContainer
 from src.Model.Transform import linear_transform
 from src.Controller.PathHandler import data_path
@@ -391,6 +397,8 @@ class MainPageCallClass:
 
     # This function runs Anonymization on button click
     def run_anonymization(self, raw_dvh):
+        if not FEATURE_TOGGLE_PSEUDONYMISE:
+            raise ImportError("Unable to import pymedphys")
         path = self.patient_dict_container.path
         dataset = self.patient_dict_container.dataset
         filepaths = self.patient_dict_container.filepaths

--- a/src/View/AddOnOptions.py
+++ b/src/View/AddOnOptions.py
@@ -152,8 +152,12 @@ class UIAddOnOptions(object):
         self.option_layout.addWidget(self.note, 2, 0, 1, 3)
 
         self.layout.addWidget(self.option_widget, 0, 1, 1, 3)
-        hspacer = QtWidgets.QSpacerItem(1,1) #QtWidgets.QSizePolicy.Expanding,
-                                       # QtWidgets.QSizePolicy.Minimum)
+        try:
+            # PySide6 worked on Windows
+            hspacer = QtWidgets.QSpacerItem(QtWidgets.QSizePolicy.Expanding,QtWidgets.QSizePolicy.Minimum)
+        except TypeError:
+            # PySide6 needed for Ubuntu 22.04 (perhaps due to PySide 6.4.0.1)
+            hspacer = QtWidgets.QSpacerItem(1,1) 
         self.layout.addItem(hspacer, 1, 1)
         self.layout.addWidget(self.apply_button, 1, 2)
         self.layout.addWidget(self.cancel_button, 1, 3)

--- a/src/View/AddOnOptions.py
+++ b/src/View/AddOnOptions.py
@@ -152,8 +152,8 @@ class UIAddOnOptions(object):
         self.option_layout.addWidget(self.note, 2, 0, 1, 3)
 
         self.layout.addWidget(self.option_widget, 0, 1, 1, 3)
-        hspacer = QtWidgets.QSpacerItem(QtWidgets.QSizePolicy.Expanding,
-                                        QtWidgets.QSizePolicy.Minimum)
+        hspacer = QtWidgets.QSpacerItem(1,1) #QtWidgets.QSizePolicy.Expanding,
+                                       # QtWidgets.QSizePolicy.Minimum)
         self.layout.addItem(hspacer, 1, 1)
         self.layout.addWidget(self.apply_button, 1, 2)
         self.layout.addWidget(self.cancel_button, 1, 3)

--- a/src/View/OpenPatientWindow.py
+++ b/src/View/OpenPatientWindow.py
@@ -568,7 +568,7 @@ class UIOpenPatientWindow(object):
         def recurse(parent_item: QTreeWidgetItem):
             for i in range(parent_item.childCount()):
                 child = parent_item.child(i)
-                if int(child.flags()) & int(Qt.ItemIsUserCheckable) and \
+                if child.flags() & Qt.ItemIsUserCheckable and \
                         child.checkState(0) == Qt.Checked:
                     checked_items.append(child)
                 grand_children = child.childCount()

--- a/src/View/addons/ImageFusionAddOnOption.py
+++ b/src/View/addons/ImageFusionAddOnOption.py
@@ -68,8 +68,14 @@ class ImageFusionOptions(object):
         self.gridLayout.setVerticalSpacing(0)
 
         # Create horizontal spacer in the middle of the grid
-        hspacer = QtWidgets.QSpacerItem(QtWidgets.QSizePolicy.Expanding,
-                                        QtWidgets.QSizePolicy.Minimum)
+        try:
+            # PySide6 worked on Windows
+            hspacer = QtWidgets.QSpacerItem(QtWidgets.QSizePolicy.Expanding,QtWidgets.QSizePolicy.Minimum)
+        except TypeError:
+            # PySide6 needed for Ubuntu 22.04 (perhaps due to PySide 6.4.0.1)
+            # no idea if these are appropriate default values
+            hspacer = QtWidgets.QSpacerItem(16,5) 
+        
         self.gridLayout.addItem(hspacer, 0, 5, 16, 1)
 
         # Labels

--- a/src/View/mainpage/DicomAxialView.py
+++ b/src/View/mainpage/DicomAxialView.py
@@ -249,7 +249,7 @@ class DicomAxialView(DicomView):
         col_img = dataset['Columns'].value
         window = self.patient_dict_container.get("window")
         level = self.patient_dict_container.get("level")
-        slice_pos = dataset['SliceLocation'].value
+        slice_pos = dataset['ImagePositionPatient'].value[2]
 
         if hasattr(dataset, 'PatientPosition'):
             patient_pos = dataset['PatientPosition'].value

--- a/test/test_model_worker.py
+++ b/test/test_model_worker.py
@@ -1,10 +1,10 @@
 from unittest import mock
 from unittest.mock import Mock
+import pytest
 
 from PySide6.QtCore import QThreadPool
 
 from src.Model.Worker import Worker
-
 
 class FakeClass:
     def func_result(self, result):
@@ -82,14 +82,14 @@ def test_worker_result_signal(qtbot, monkeypatch):
         thing.func_to_test.assert_called_with("test", 3)
         mock_func_result.assert_called_with(5)
 
-
+@pytest.mark.qt_no_exception_capture
 def test_worker_error_signal(qtbot):
     """
     Testing return value of worker's called function through result signal.
     """
 
     thing = FakeClass()
-    thing.func_to_test = Mock(side_effect=ValueError())
+    thing.func_to_test = Mock(side_effect=ValueError("Some Error"))
 
     w = Worker(thing.func_to_test, "test", 3)
 
@@ -100,7 +100,10 @@ def test_worker_error_signal(qtbot):
             threadpool.start(w)
 
         kall = thing.func_error.call_args
+        print("kall returned")
         args, kwargs = kall
+        print(kwargs)
+        print(args)
 
         thing.func_to_test.assert_called_with("test", 3)
         assert isinstance(args[0][1], ValueError)

--- a/test/test_model_worker.py
+++ b/test/test_model_worker.py
@@ -100,10 +100,7 @@ def test_worker_error_signal(qtbot):
             threadpool.start(w)
 
         kall = thing.func_error.call_args
-        print("kall returned")
         args, kwargs = kall
-        print(kwargs)
-        print(args)
 
         thing.func_to_test.assert_called_with("test", 3)
         assert isinstance(args[0][1], ValueError)


### PR DESCRIPTION
Workaround: wrapping import of pymedphys with try/except due to recursive import that fails
Fix: eliminated casting of bitmask to int before applying bitwise OR 
Fix: wrapping initialisation of QSpacerItem with try/except to address signature variations

I'll investigate why the import of pymedphys is recursing in to areas of pymedphys that are not needed  for pseudonymisation, but for now the workaround will give the user an error when they try to pseudonymise rather than prevent them from launching OnkoDICOM at all,.