### PR TITLE
Cache test file

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -14,9 +14,10 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Python 3.9
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
+        # cache: 'pip'
 
     - name: Install plastimatch
       run: |
@@ -40,20 +41,44 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
-    - name: Testing setup
+    - uses: actions/cache/restore@v3
+      name: restore test data
+      id: restore
+      with:
+        path: ~/DICOM-RT-02.zip
+        # remember to update the key when changing the test dataset
+        key: 'https://zenodo.org/record/5147737/files/DICOM-RT-02.zip'
+
+    - name: download test data
+      if: steps.restore.outputs.cache-hit != 'true'
       run: |
-        pip install pytest-xvfb pytest-cov
-        sudo apt-get update
-        sudo apt-get install xvfb libxkbcommon-x11-0 herbstluftwm libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libopengl0 freeglut3 freeglut3-dev
-        # install test data
-        sudo apt-get install wget unzip
+        sudo apt-get install wget
         wget -P ~ https://zenodo.org/record/5147737/files/DICOM-RT-02.zip
+
+    # save the test data to cache ASAP, even when the entire workflow fail
+    - name: save new cache
+      uses: actions/cache/save@v3
+      if: steps.restore.outputs.cache-hit != 'true'
+      with:
+        path: ~/DICOM-RT-02.zip
+        # remember to update the key when changing the test dataset
+        key: 'https://zenodo.org/record/5147737/files/DICOM-RT-02.zip'
+
+    - name: install test data
+      run: |
+        sudo apt-get install unzip
         mkdir test/testdata
         mkdir test/batchtestdata
         unzip ~/DICOM-RT-02.zip -d test/testdata
         unzip ~/DICOM-RT-02.zip -d test/batchtestdata
         sudo chmod -R 777 test/testdata
         sudo chmod -R 777 test/batchtestdata
+
+    - name: Testing setup
+      run: |
+        pip install pytest-xvfb pytest-cov
+        sudo apt-get update
+        sudo apt-get install xvfb libxkbcommon-x11-0 herbstluftwm libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libopengl0 freeglut3 freeglut3-dev
         # sudo Xvfb :1 -screen 0 1024x768x24 </dev/null &
         /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1920x1200x24 -ac +extension GLX
         sleep 3

--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@ OnkoDICOM is an Open Source DICOM-RT viewer with enhanced capabilities that make
 
 The enhanced capabilities of OnkoDICOM.2020:
 1. pseudo-anonymisation
-- at each pseudoanonymisation, the image set is copied to a new directory and the doublet of 'Old_ID':'New_ID' is written into a CSV file that the user can archive securely for future reference if needed.  
-3. spreadsheet exports
-- DVHs of all ROIs
-- PyRadiomics output from all ROIs (currently ~132 features)
-- clinical description of the patient's disease which can be updated.
-4. ROI manipulation
-- rename ROI to a list of Standardised Names (the provided list is correlated to an FMA_ID and so is customisable to your own usage if needed)
-- delete ROI (for all those 'Rings of Bob' and other ROIs used in plan creation)
-- add ROI (at present this requires a RTSTRUCT file be present, uses a pixel value definition and manual cleaning on a single slice)
+   - at each pseudoanonymisation, the image set is copied to a new directory and the doublet of 'Old_ID':'New_ID' is written into a CSV file that the user can archive securely for future reference if needed.  
+2. spreadsheet exports
+   - DVHs of all ROIs
+   - PyRadiomics output from all ROIs (currently ~132 features)
+   - clinical description of the patient's disease which can be updated.
+3. ROI manipulation
+   - rename ROI to a list of Standardised Names (the provided list is correlated to an FMA_ID and so is customisable to your own usage if needed)
+   - delete ROI (for all those 'Rings of Bob' and other ROIs used in plan creation)
+   - add ROI (at present this requires a RTSTRUCT file be present, uses a pixel value definition and manual cleaning on a single slice)
 
 OnkoDICOM is built on open source technologies, such as pydicom, dicompyler-core, PySide6, PIL, and matplotlib. Although built in Python, its forms are cross-platform, and we welcome contributions from the wider community via GitHub https://github.com/didymo/OnkoDICOM.
 
@@ -28,21 +28,24 @@ Note that in order to utilise OnkoDICOM's radiomics toolset, the external progra
 ### Testing
 
 In the root directory, initiate the virtual environment using:
-
+```
 source venv/bin/activate
+```
+
 To run the tests run:
-
+```
 python -m pytest test/
-
+```
 
 the code coverage reporting is done with
-
+```
 pip install pytest-cov
-
+```
 found here:
 https://pypi.org/project/pytest-cov/
 
 To run the report:
-python -m pytest   --cov=src     test/
-
+```
+python -m pytest --cov=src test/
+```
 


### PR DESCRIPTION
Cache the test file (DICOM-RT-02.zip). This saves at least 3 minutes (sometimes 5 minutes) for each build.

Note: pip is not cached if we always want to use the **latest** version of packages