### PR TITLE
Change DVH.CSV export

### DIFF
--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -150,31 +150,41 @@ def dvh2pandas(dict_dvh, patient_id):
     csv_header.append('ROI')
     csv_header.append('Volume (mL)')
 
-    max_roi_dose = 0
-
     dvh_csv_list = []
 
+    # DVH.CSV EXPORT
+    
+    #Row in centiGray cGy
     for i in dict_dvh:
         dvh_roi_list = []
+
         dvh = dict_dvh[i]
         name = dvh.name
         volume = dvh.volume
+
         dvh_roi_list.append(patient_id)
         dvh_roi_list.append(name)
         dvh_roi_list.append(volume)
+
         dose = dvh.relative_volume.counts
 
+        current_cGy_list = []
+        current_percentage_range = 100
         for i in range(0, len(dose), 10):
-            dvh_roi_list.append(dose[i])
-            # Update the maximum dose value, if current dose
-            # exceeds the current maximum dose
-            if i > max_roi_dose:
-                max_roi_dose = i
+            if (current_percentage_range < 0)
+                break
+            if (dose[i] >= current_percentage_range)
+                cGy = str(i) + 'cGy: ' + str(dose[0])
+                current_cGy_list.append(cGy)
+            else
+                dvh_roi_list.append(current_cGy_list)
+                current_percentage_range = current_percentage_range - 0.5                
 
         dvh_csv_list.append(dvh_roi_list)
-
-    for i in range(0, max_roi_dose + 1, 10):
-        csv_header.append(str(i) + 'cGy')
+    
+    #Column in percentage %
+    for i in np.arange(100, 0 - 0.5, -0.5):
+        csv_header.append(str(i) + '%')
 
     # Convert the list into pandas dataframe, with 2 digit rounding.
     pddf = pd.DataFrame(dvh_csv_list, columns=csv_header).round(2)


### PR DESCRIPTION
The current DVH.CSV export has columns in 'centiGray' and rows in '%'.

Change output to columns in '%' (100%, 99.5%, 99.0%, .....) and rows in 'centiGray' (no decimals, normal rounding). This will produce a spreadsheet with a fixed number of columns irrespective of the prescribed radiation dose.