### PR TITLE
Change DVH.CSV export: Change dvh output to percentvolume vs dose

### DIFF
--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -187,7 +187,7 @@ def dvh2pandas(dict_dvh, patient_id):
                 else:
                     last_volume = trough_i
             if last_volume != -1:
-                dvh_roi_list.append(str(last_volume) + 'cGy')
+                dvh_roi_list.append(str(round(last_volume)) + 'cGy')
             else:
                 dvh_roi_list.append('')
         dvh_csv_list.append(dvh_roi_list)

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -170,15 +170,15 @@ def dvh2pandas(dict_dvh, patient_id):
 
         current_cGy_list = []
         current_percentage_range = 100
-        for i in range(0, len(dose), 10):
+        for j in range(0, len(dose), 10):
             if (current_percentage_range < 0):
                 break
-            if (dose[i] >= current_percentage_range):
-                cGy = str(i) + 'cGy: ' + str(dose[0])
+            if (dose[j] >= current_percentage_range):
+                cGy = str(j) + 'cGy: ' + str(dose[j])
                 current_cGy_list.append(cGy)
             else:
                 dvh_roi_list.append(current_cGy_list)
-                current_percentage_range = current_percentage_range - 0.5                
+                current_percentage_range -= 0.5                
 
         dvh_csv_list.append(dvh_roi_list)
     
@@ -187,7 +187,7 @@ def dvh2pandas(dict_dvh, patient_id):
         csv_header.append(str(i) + '%')
 
     # Convert the list into pandas dataframe, with 2 digit rounding.
-    pddf = pd.DataFrame(dvh_csv_list, columns=csv_header)
+    pddf = pd.DataFrame(dvh_csv_list, columns=csv_header).round(2)
     # Fill empty blocks with 0.0
     pddf.fillna(0.0, inplace=True)
     pddf.set_index('Patient ID', inplace=True)

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -154,33 +154,7 @@ def dvh2pandas(dict_dvh, patient_id):
 
     # DVH.CSV EXPORT
     
-    #Row in centiGray cGy
-    for i in dict_dvh:
-        dvh_roi_list = []
-
-        dvh = dict_dvh[i]
-        name = dvh.name
-        volume = dvh.volume
-
-        dvh_roi_list.append(patient_id)
-        dvh_roi_list.append(name)
-        dvh_roi_list.append(volume)
-
-        dose = dvh.relative_volume.counts
-
-        current_cGy_list = []
-        current_percentage_range = 100
-        for j in range(0, len(dose), 10):
-            if (current_percentage_range < 0):
-                break
-            if (dose[j] >= current_percentage_range):
-                cGy = str(j) + 'cGy: ' + str(dose[j])
-                current_cGy_list.extend(cGy)
-            else:
-                dvh_roi_list.append(current_cGy_list)
-                current_percentage_range -= 0.5                
-
-        dvh_csv_list.append(dvh_roi_list)
+    
     
     #Column in percentage %
     for i in np.arange(100, 0 - 0.5, -0.5):

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -187,7 +187,7 @@ def dvh2pandas(dict_dvh, patient_id):
         csv_header.append(str(i) + '%')
 
     # Convert the list into pandas dataframe, with 2 digit rounding.
-    pddf = pd.DataFrame(dvh_csv_list, columns=csv_header).round(2)
+    pddf = pd.DataFrame(dvh_csv_list, columns=csv_header)
     # Fill empty blocks with 0.0
     pddf.fillna(0.0, inplace=True)
     pddf.set_index('Patient ID', inplace=True)

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -187,7 +187,8 @@ def dvh2pandas(dict_dvh, patient_id):
         csv_header.append(str(i) + '%')
 
     # Convert the list into pandas dataframe, with 2 digit rounding.
-    pddf = pd.DataFrame(dvh_csv_list, columns=csv_header).round(2)
+    pddf = pd.DataFrame(dvh_csv_list, columns=csv_header)
+    pddf = pddf.round(2)
     # Fill empty blocks with 0.0
     pddf.fillna(0.0, inplace=True)
     pddf.set_index('Patient ID', inplace=True)

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -166,23 +166,23 @@ def dvh2pandas(dict_dvh, patient_id):
         
         dose = dvh.relative_volume.counts
         
-        current_dose_index = 0
-        tempt_peak_dose_index = 0
+        trough_i = 0
+        peak_i = 0
         for percent in np.arange(100, -0.5, -0.5):
             last_volume = -1
-            for cgy in range(current_dose_index, len(dose), 10):
+            for cgy in range(trough_i, len(dose), 10):
                 if dose[cgy] == percent:
                     last_volume = cgy
                 elif dose[cgy] > percent:
-                    tempt_peak_dose_index = cgy
+                    peak_i = cgy
                 elif dose[cgy] < percent:
-                    current_dose_index = cgy
+                    trough_i = cgy
                     break
-            if last_volume == -1 and tempt_peak_dose_index != 0:
-                volume_drop_per = 10 * (dose[tempt_peak_dose_index] - dose[cgy])/(tempt_peak_dose_index - cgy)
-                drop_per = percent - dose[tempt_peak_dose_index]
+            if last_volume == -1 and peak_i != 0:
+                volume_drop_per = 10 * (dose[peak_i] - dose[trough_i])/(peak_i - trough_i)
+                drop_per = percent - dose[peak_i]
                 substract_amount = drop_per/volume_drop_per * 10
-                last_volume = cgy - substract_amount
+                last_volume = trough_i - substract_amount
             if last_volume != -1:
                 dvh_roi_list.append(str(round(last_volume // 1)) + 'cGy')
             else:

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -169,9 +169,9 @@ def dvh2pandas(dict_dvh, patient_id):
         current_percentage_range = 100
         for j in range(0, len(dose), 10):
             print(current_percentage_range)
-            if current_percentage_range < -0.5:
+            if current_percentage_range < 0:
                 break
-            if dose[j] >= current_percentage_range:
+            elif dose[j] >= current_percentage_range:
                 cGy = '[' + str(j) + 'cGy: ' + str(dose[j]) + ']'
                 current_cGy_list += cGy
             else:

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -165,12 +165,22 @@ def dvh2pandas(dict_dvh, patient_id):
         dvh_roi_list.append(volume)
         dose = dvh.relative_volume.counts
 
-                  
+        current_cGy_list = ''
+        current_percentage_range = 100
+        for j in range(0, len(dose), 10):
+            if current_percentage_range < 0:
+                break
+            if dose[j] >= current_percentage_range:
+                cGy = '[' + str(j) + 'cGy: ' + str(dose[j]) ']'
+                current_cGy_list += cGy
+            else:
+                dvh_roi_list.append(current_cGy_list)
+                current_percentage_range -= 0.5                    
 
         dvh_csv_list.append(dvh_roi_list)
     
     #Column in percentage %
-    for i in np.arange(100, 0 - 0.5, -0.5):
+    for i in np.arange(100, 0, -0.5):
         csv_header.append(str(i) + '%')
 
     # Convert the list into pandas dataframe, with 2 digit rounding.

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -188,7 +188,6 @@ def dvh2pandas(dict_dvh, patient_id):
     pddf = pd.DataFrame(dvh_csv_list).round(2)
     # Fill empty blocks with 0.0
     pddf.fillna(0.0, inplace=True)
-    pddf.set_index('Patient ID', inplace=True)
 
     # Return pandas dataframe
     return pddf

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -157,11 +157,9 @@ def dvh2pandas(dict_dvh, patient_id):
     #Row in centiGray cGy
     for i in dict_dvh:
         dvh_roi_list = []
-        
         dvh = dict_dvh[i]
         name = dvh.name
         volume = dvh.volume
-        
         dvh_roi_list.append(patient_id)
         dvh_roi_list.append(name)
         dvh_roi_list.append(volume)
@@ -186,7 +184,7 @@ def dvh2pandas(dict_dvh, patient_id):
                     current_dose_index = cgy
                     break
             if last_volume != -1:
-                dvh_roi_list.append(str(last_volume // 1) + 'cGy')
+                dvh_roi_list.append(str(round(last_volume // 1)) + 'cGy')
             else:
                 dvh_roi_list.append('')
         dvh_csv_list.append(dvh_roi_list)

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -168,8 +168,6 @@ def dvh2pandas(dict_dvh, patient_id):
         current_cGy_list = ''
         current_percentage_range = 100
         for j in range(0, len(dose), 10):
-            if current_percentage_range < 0:
-                break
             if dose[j] < current_percentage_range + 0.5 and dose[j] >= current_percentage_range:
                 cGy = '[' + str(j) + 'cGy: ' + str(dose[j].round(2)) + ']'
                 current_cGy_list += cGy
@@ -181,7 +179,7 @@ def dvh2pandas(dict_dvh, patient_id):
         dvh_csv_list.append(dvh_roi_list)
     
     #Column in percentage %
-    for i in np.arange(100, 0, -0.5):
+    for i in np.arange(100, -0.5, -0.5):
         csv_header.append(str(i) + '%')
 
     # Convert the list into pandas dataframe, with 2 digit rounding.

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -168,8 +168,8 @@ def dvh2pandas(dict_dvh, patient_id):
         for m in np.arange(100, -0.5, -0.5):
             current_cGy_list = ''
             for n in range(0, len(dose), 10):
-                if dose[n] < m + 0.5 and dose[n] >= m:
-                    cGy = '[' + str(n) + 'cGy: ' + str(dose[n].round(2)) + ']'
+                if dose[n] < (m + 0.5) and dose[n] >= m:
+                    cGy = '[' + str(n) + 'cGy: ' + str(dose[n]) + ']'
                     current_cGy_list += cGy
             dvh_roi_list.append(current_cGy_list)  
              

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -183,7 +183,7 @@ def dvh2pandas(dict_dvh, patient_id):
                     volume_per_drop = 10 * (dose[peak_i] - dose[trough_i])/(peak_i - trough_i)
                     per_drop = dose[peak_i] - percent
                     substract_amount = per_drop/volume_per_drop * 10
-                    last_volume = peak_i - substract_amount
+                    last_volume = trough_i - substract_amount
                 else:
                     last_volume = trough_i
             if last_volume != -1:

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -177,7 +177,7 @@ def dvh2pandas(dict_dvh, patient_id):
                     last_volume = cgy
                 elif dose[cgy] > percent:
                     tempt_peak_dose_index = cgy
-                elif dose[cgy] < percent or current_dose_index == len(dose) - 1:
+                elif dose[cgy] < percent or cgy == len(dose) - 1:
                     if last_volume == -1 and tempt_peak_dose_index != 0:
                         volume_drop_per = 10 * (dose[tempt_peak_dose_index] - dose[cgy])/(tempt_peak_dose_index - cgy)
                         drop_per = percent - dose[tempt_peak_dose_index]

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -172,19 +172,21 @@ def dvh2pandas(dict_dvh, patient_id):
         tempt_peak_dose_index = 0
         for percent in np.arange(100, -0.5, -0.5):
             last_volume = -1
-            for cGy in range(current_dose_index, len(dose), 10):
-                if dose[cGy] == percent:
-                    last_volume = cGy
-                else:
-                    if dose[cGy] >= percent - 0.5:
-                        tempt_peak_dose_index = cGy
-                    else:
-                        volume_drop_per = 10 * (dose[tempt_peak_dose_index] - dose[cGy])/(tempt_peak_dose_index - cGy)
+            for cgy in range(current_dose_index, len(dose), 10):
+                if dose[cgy] < percent:
+                    current_dose_index = cgy
+                    if dose[cgy] > percent - 0.5:
+                        tempt_peak_dose_index = cgy
+                    elif dose[cgy] < percent - 0.5:
+                        volume_drop_per = 10 * (dose[tempt_peak_dose_index] - dose[cgy])/(tempt_peak_dose_index - cgy)
                         drop_per = percent - dose[tempt_peak_dose_index]
                         substract_amount = drop_per/volume_drop_per * 10
-                        last_volume = cGy - substract_amount
-                        
-                        current_dose_index = cGy
+                        last_volume = cgy - substract_amount
+                    break
+                if dose[cgy] > percent:
+                    tempt_peak_dose_index = cgy
+                if dose[cgy] == percent:
+                    last_volume = cgy
             dvh_roi_list.append(str(last_volume) + 'cGy')
         
         dvh_csv_list.append(dvh_roi_list)

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -174,22 +174,22 @@ def dvh2pandas(dict_dvh, patient_id):
             last_volume = -1
             for cgy in range(current_dose_index, len(dose), 10):
                 if dose[cgy] < percent:
-                    current_dose_index = cgy
-                    if dose[cgy] > percent - 0.5:
-                        tempt_peak_dose_index = cgy
-                    elif dose[cgy] < percent - 0.5:
+                    if last_volume == -1 and tempt_peak_dose_index != 0:
                         volume_drop_per = 10 * (dose[tempt_peak_dose_index] - dose[cgy])/(tempt_peak_dose_index - cgy)
                         drop_per = percent - dose[tempt_peak_dose_index]
                         substract_amount = drop_per/volume_drop_per * 10
                         last_volume = cgy - substract_amount
+                    current_dose_index = cgy
                     break
                 if dose[cgy] > percent:
                     tempt_peak_dose_index = cgy
                 if dose[cgy] == percent:
                     last_volume = cgy
             dvh_roi_list.append(str(last_volume) + 'cGy')
-        
+        # Row in centiGray
         dvh_csv_list.append(dvh_roi_list)
+        current_dose_index = 0
+        tempt_peak_dose_index = 0
             
     #Column in percentage %
     for i in np.arange(100, -0.5, -0.5):

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -168,8 +168,6 @@ def dvh2pandas(dict_dvh, patient_id):
         current_cGy_list = ''
         current_percentage_range = 100
         for j in range(0, len(dose), 10):
-            if current_percentage_range < 0:
-                break
             if dose[j] >= current_percentage_range:
                 cGy = '[' + str(j) + 'cGy: ' + str(dose[j]) + ']'
                 current_cGy_list += cGy
@@ -181,7 +179,7 @@ def dvh2pandas(dict_dvh, patient_id):
         dvh_csv_list.append(dvh_roi_list)
     
     #Column in percentage %
-    for i in np.arange(100, 0, -0.5):
+    for i in np.arange(100, 0 - 0.5, -0.5):
         csv_header.append(str(i) + '%')
 
     # Convert the list into pandas dataframe, with 2 digit rounding.

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -180,7 +180,7 @@ def dvh2pandas(dict_dvh, patient_id):
                     break
             if last_volume == -1 and peak_i != 0:
                 if dose[peak_i] != dose[trough_i]:
-                    volume_per_drop = 10 * (dose[peak_i] - dose[trough_i])/(peak_i - trough_i)
+                    volume_per_drop = -10 * (dose[peak_i] - dose[trough_i])/(peak_i - trough_i)
                     per_drop = dose[peak_i] - percent
                     substract_amount = per_drop/volume_per_drop * 10
                     last_volume = trough_i - substract_amount

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -157,33 +157,37 @@ def dvh2pandas(dict_dvh, patient_id):
     #Row in centiGray cGy
     for i in dict_dvh:
         dvh_roi_list = []
+        
         dvh = dict_dvh[i]
         name = dvh.name
         volume = dvh.volume
+        
         dvh_roi_list.append(patient_id)
         dvh_roi_list.append(name)
         dvh_roi_list.append(volume)
+        
         dose = dvh.relative_volume.counts
         
-        last_volume = '0cGy'
-        high_dose = dose[0]
-        for i in range(0, len(dose), 10):
-            if percentage >= dose[0]:
-                high_dose =  str(n) + 'cGy'
-            else:
-                
-                percentage = dose[0]
-
-        for m in np.arange(100, -0.5, -0.5):
-            current_cGy_list = ''
-            for n in range(0, len(dose), 10):
-                if dose[n] < (m + 0.5) and dose[n] >= m:
-                    cGy = '[' + str(n) + 'cGy: ' + str(dose[n]) + ']'
-                    current_cGy_list += cGy
-            dvh_roi_list.append(current_cGy_list)  
-             
-        dvh_csv_list.append(dvh_roi_list)
-    
+        current_dose_index = 0
+        tempt_peak_dose_index = 0
+        for percent in np.arange(100, -0.5, -0.5):
+            last_volume = 0
+            for centiGray in range(current_dose_index, len(dose), 10):
+                if dose[centiGray] == percent:
+                    last_volume = centiGray
+                else:
+                    if dose[centiGray] >= percent - 0.5:
+                        current_dose_index = centiGray
+                        tempt_peak_dose_index = centiGray
+                        break
+                    else:
+                        volume_drop_per = 10 * (dose[tempt_peak_dose_index] - dose[centiGray])/(tempt_peak_dose_index - centiGray)
+                        drop_per = percent - dose[tempt_peak_dose_index]
+                        substract_amount = drop_per/volume_drop_per * 10
+                        last_volume = centiGray - substract_amount
+            dvh_csv_list.append(str(last_volume) + 'cGy')
+            
+            
     #Column in percentage %
     for i in np.arange(100, -0.5, -0.5):
         csv_header.append(str(i) + '%')

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -169,11 +169,15 @@ def dvh2pandas(dict_dvh, patient_id):
         dose = dvh.relative_volume.counts
         
         current_dose_index = 0
-        tempt_peak_dose_index = 0
         for percent in np.arange(100, -0.5, -0.5):
             last_volume = -1
+            tempt_peak_dose_index = 0
             for cgy in range(current_dose_index, len(dose), 10):
-                if dose[cgy] < percent:
+                if dose[cgy] == percent:
+                    last_volume = cgy
+                elif dose[cgy] > percent:
+                    tempt_peak_dose_index = cgy
+                elif dose[cgy] < percent or current_dose_index == len(dose) - 1:
                     if last_volume == -1 and tempt_peak_dose_index != 0:
                         volume_drop_per = 10 * (dose[tempt_peak_dose_index] - dose[cgy])/(tempt_peak_dose_index - cgy)
                         drop_per = percent - dose[tempt_peak_dose_index]
@@ -181,15 +185,11 @@ def dvh2pandas(dict_dvh, patient_id):
                         last_volume = cgy - substract_amount
                     current_dose_index = cgy
                     break
-                if dose[cgy] > percent:
-                    tempt_peak_dose_index = cgy
-                if dose[cgy] == percent:
-                    last_volume = cgy
-            dvh_roi_list.append(str(last_volume) + 'cGy')
-        # Row in centiGray
+            if last_volume != -1:
+                dvh_roi_list.append(str(last_volume) + 'cGy')
+            else:
+                dvh_roi_list.append('')
         dvh_csv_list.append(dvh_roi_list)
-        current_dose_index = 0
-        tempt_peak_dose_index = 0
             
     #Column in percentage %
     for i in np.arange(100, -0.5, -0.5):

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -165,17 +165,7 @@ def dvh2pandas(dict_dvh, patient_id):
         dvh_roi_list.append(volume)
         dose = dvh.relative_volume.counts
 
-        current_cGy_list = ''
-        current_percentage_range = 100
-        for j in range(0, len(dose), 10):
-            if (current_percentage_range < 0):
-                break
-            if (dose[j] >= current_percentage_range):
-                cGy = '[' + str(j) + 'cGy: ' + str(dose[j]) + ']'
-                current_cGy_list += cGy
-            else:
-                dvh_roi_list.append(current_cGy_list)
-                current_percentage_range -= 0.5                    
+                  
 
         dvh_csv_list.append(dvh_roi_list)
     

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -164,6 +164,15 @@ def dvh2pandas(dict_dvh, patient_id):
         dvh_roi_list.append(name)
         dvh_roi_list.append(volume)
         dose = dvh.relative_volume.counts
+        
+        last_volume = '0cGy'
+        high_dose = dose[0]
+        for i in range(0, len(dose), 10):
+            if percentage >= dose[0]:
+                high_dose =  str(n) + 'cGy'
+            else:
+                
+                percentage = dose[0]
 
         for m in np.arange(100, -0.5, -0.5):
             current_cGy_list = ''

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -186,7 +186,7 @@ def dvh2pandas(dict_dvh, patient_id):
                     current_dose_index = cgy
                     break
             if last_volume != -1:
-                dvh_roi_list.append(str(last_volume) + 'cGy')
+                dvh_roi_list.append(str(last_volume // 1) + 'cGy')
             else:
                 dvh_roi_list.append('')
         dvh_csv_list.append(dvh_roi_list)

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -168,6 +168,7 @@ def dvh2pandas(dict_dvh, patient_id):
         current_cGy_list = ''
         current_percentage_range = 100
         for j in range(0, len(dose), 10):
+            print(current_percentage_range)
             if current_percentage_range < -0.5:
                 break
             if dose[j] >= current_percentage_range:

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -170,13 +170,15 @@ def dvh2pandas(dict_dvh, patient_id):
         for j in range(0, len(dose), 10):
             if current_percentage_range < 0:
                 break
-            if dose[j] < current_percentage_range + 0.5 and dose[j] >= current_percentage_range:
+            if dose[j] >= current_percentage_range:
                 cGy = '[' + str(j) + 'cGy: ' + str(dose[j].round(2)) + ']'
                 current_cGy_list += cGy
             else:
                 dvh_roi_list.append(current_cGy_list)
                 current_percentage_range -= 0.5  
-                current_cGy_list = ''                  
+                current_cGy_list = ''
+                cGy = '[' + str(j) + 'cGy: ' + str(dose[j].round(2)) + ']'
+                current_cGy_list += cGy                  
 
         dvh_csv_list.append(dvh_roi_list)
     
@@ -185,9 +187,10 @@ def dvh2pandas(dict_dvh, patient_id):
         csv_header.append(str(i) + '%')
 
     # Convert the list into pandas dataframe, with 2 digit rounding.
-    pddf = pd.DataFrame(dvh_csv_list).round(2)
+    pddf = pd.DataFrame(dvh_csv_list, columns=csv_header).round(2)
     # Fill empty blocks with 0.0
     pddf.fillna(0.0, inplace=True)
+    pddf.set_index('Patient ID', inplace=True)
 
     # Return pandas dataframe
     return pddf

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -169,9 +169,9 @@ def dvh2pandas(dict_dvh, patient_id):
         dose = dvh.relative_volume.counts
         
         current_dose_index = 0
+        tempt_peak_dose_index = 0
         for percent in np.arange(100, -0.5, -0.5):
             last_volume = -1
-            tempt_peak_dose_index = 0
             for cgy in range(current_dose_index, len(dose), 10):
                 if dose[cgy] == percent:
                     last_volume = cgy

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -172,21 +172,19 @@ def dvh2pandas(dict_dvh, patient_id):
         tempt_peak_dose_index = 0
         for percent in np.arange(100, -0.5, -0.5):
             last_volume = -1
-            for centiGray in range(current_dose_index, len(dose), 10):
-                if dose[centiGray] == percent:
-                    last_volume = centiGray
-                '''
+            for cGy in range(current_dose_index, len(dose), 10):
+                if dose[cGy] == percent:
+                    last_volume = cGy
                 else:
-                    if dose[centiGray] >= percent - 0.5:
-                        tempt_peak_dose_index = centiGray
+                    if dose[cGy] >= percent - 0.5:
+                        tempt_peak_dose_index = cGy
                     else:
-                        volume_drop_per = 10 * (dose[tempt_peak_dose_index] - dose[centiGray])/(tempt_peak_dose_index - centiGray)
+                        volume_drop_per = 10 * (dose[tempt_peak_dose_index] - dose[cGy])/(tempt_peak_dose_index - cGy)
                         drop_per = percent - dose[tempt_peak_dose_index]
                         substract_amount = drop_per/volume_drop_per * 10
-                        last_volume = centiGray - substract_amount
+                        last_volume = cGy - substract_amount
                         
-                        current_dose_index = centiGray
-                '''
+                        current_dose_index = cGy
             dvh_roi_list.append(str(last_volume) + 'cGy')
         
         dvh_csv_list.append(dvh_roi_list)

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -171,18 +171,21 @@ def dvh2pandas(dict_dvh, patient_id):
         for percent in np.arange(100, -0.5, -0.5):
             last_volume = -1
             for cgy in range(trough_i, len(dose), 10):
+                trough_i = cgy
                 if dose[cgy] == percent:
                     last_volume = cgy
                 elif dose[cgy] > percent:
                     peak_i = cgy
                 elif dose[cgy] < percent:
-                    trough_i = cgy
                     break
             if last_volume == -1 and peak_i != 0:
-                volume_drop_per = 10 * (dose[peak_i] - dose[trough_i])/(peak_i - trough_i)
-                drop_per = percent - dose[peak_i]
-                substract_amount = drop_per/volume_drop_per * 10
-                last_volume = trough_i - substract_amount
+                if dose[peak_i] != dose[trough_i]:
+                    volume_per_drop = 10 * (dose[peak_i] - dose[trough_i])/(peak_i - trough_i)
+                    per_drop = dose[peak_i] - percent
+                    substract_amount = per_drop/volume_per_drop * 10
+                    last_volume = trough_i - substract_amount
+                else:
+                    last_volume = dose[trough_i]
             if last_volume != -1:
                 dvh_roi_list.append(str(last_volume // 1) + 'cGy')
             else:

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -157,24 +157,25 @@ def dvh2pandas(dict_dvh, patient_id):
     #Row in centiGray cGy
     for i in dict_dvh:
         dvh_roi_list = []
-
         dvh = dict_dvh[i]
         name = dvh.name
         volume = dvh.volume
-
         dvh_roi_list.append(patient_id)
         dvh_roi_list.append(name)
         dvh_roi_list.append(volume)
-
         dose = dvh.relative_volume.counts
 
-        current_cGy_list = []
+        current_cGy_list = ''
         current_percentage_range = 100
         for j in range(0, len(dose), 10):
             if (current_percentage_range < 0):
                 break
-            if (dose[j] == current_percentage_range):
-                cGy = str(j) + 'cGy: '              
+            if (dose[j] >= current_percentage_range):
+                cGy = '[' + str(j) + 'cGy: ' + str(dose[j]) ']'
+                current_cGy_list += cGy
+            else:
+                dvh_roi_list.append(current_cGy_list)
+                current_percentage_range -= 0.5                    
 
         dvh_csv_list.append(dvh_roi_list)
     
@@ -183,8 +184,7 @@ def dvh2pandas(dict_dvh, patient_id):
         csv_header.append(str(i) + '%')
 
     # Convert the list into pandas dataframe, with 2 digit rounding.
-    pddf = pd.DataFrame(dvh_csv_list, columns=csv_header)
-    pddf = pddf.round(2)
+    pddf = pd.DataFrame(dvh_csv_list, columns=csv_header).round(2)
     # Fill empty blocks with 0.0
     pddf.fillna(0.0, inplace=True)
     pddf.set_index('Patient ID', inplace=True)

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -184,7 +184,7 @@ def dvh2pandas(dict_dvh, patient_id):
                 substract_amount = drop_per/volume_drop_per * 10
                 last_volume = trough_i - substract_amount
             if last_volume != -1:
-                dvh_roi_list.append(str(round(last_volume // 1)) + 'cGy')
+                dvh_roi_list.append(str(last_volume // 1) + 'cGy')
             else:
                 dvh_roi_list.append('')
         dvh_csv_list.append(dvh_roi_list)

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -187,7 +187,7 @@ def dvh2pandas(dict_dvh, patient_id):
                 else:
                     last_volume = trough_i
             if last_volume != -1:
-                dvh_roi_list.append(str(round(last_volume // 1)) + 'cGy')
+                dvh_roi_list.append(str(last_volume) + 'cGy')
             else:
                 dvh_roi_list.append('')
         dvh_csv_list.append(dvh_roi_list)

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -181,7 +181,7 @@ def dvh2pandas(dict_dvh, patient_id):
         dvh_csv_list.append(dvh_roi_list)
     
     #Column in percentage %
-    for i in np.arange(100, -0.5, -0.5):
+    for i in np.arange(100, 0, -0.5):
         csv_header.append(str(i) + '%')
 
     # Convert the list into pandas dataframe, with 2 digit rounding.

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -171,12 +171,12 @@ def dvh2pandas(dict_dvh, patient_id):
         current_cGy_list = []
         current_percentage_range = 100
         for i in range(0, len(dose), 10):
-            if (current_percentage_range < 0)
+            if (current_percentage_range < 0):
                 break
-            if (dose[i] >= current_percentage_range)
+            if (dose[i] >= current_percentage_range):
                 cGy = str(i) + 'cGy: ' + str(dose[0])
                 current_cGy_list.append(cGy)
-            else
+            else:
                 dvh_roi_list.append(current_cGy_list)
                 current_percentage_range = current_percentage_range - 0.5                
 

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -182,7 +182,7 @@ def dvh2pandas(dict_dvh, patient_id):
         dvh_csv_list.append(dvh_roi_list)
     
     #Column in percentage %
-    for i in np.arange(100, -0.5, -0.5):
+    for i in np.arange(100, 0, -0.5):
         csv_header.append(str(i) + '%')
 
     # Convert the list into pandas dataframe, with 2 digit rounding.

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -175,7 +175,6 @@ def dvh2pandas(dict_dvh, patient_id):
             for centiGray in range(current_dose_index, len(dose), 10):
                 if dose[centiGray] == percent:
                     last_volume = centiGray
-                """
                 else:
                     if dose[centiGray] >= percent - 0.5:
                         current_dose_index = centiGray
@@ -186,9 +185,9 @@ def dvh2pandas(dict_dvh, patient_id):
                         drop_per = percent - dose[tempt_peak_dose_index]
                         substract_amount = drop_per/volume_drop_per * 10
                         last_volume = centiGray - substract_amount
-                """
-            dvh_csv_list.append(str(last_volume) + 'cGy')
-            
+            dvh_roi_list.append(str(last_volume) + 'cGy')
+        
+        dvh_csv_list.append(dvh_roi_list)
             
     #Column in percentage %
     for i in np.arange(100, -0.5, -0.5):

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -171,7 +171,7 @@ def dvh2pandas(dict_dvh, patient_id):
             if current_percentage_range < 0:
                 break
             if dose[j] >= current_percentage_range:
-                cGy = '[' + str(j) + 'cGy: ' + str(dose[j]) ']'
+                cGy = '[' + str(j) + 'cGy: ' + str(dose[j]) + ']'
                 current_cGy_list += cGy
             else:
                 dvh_roi_list.append(current_cGy_list)

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -187,10 +187,9 @@ def dvh2pandas(dict_dvh, patient_id):
         csv_header.append(str(i) + '%')
 
     # Convert the list into pandas dataframe, with 2 digit rounding.
-    pddf = pd.DataFrame(dvh_csv_list, columns=csv_header).round(2)
+    pddf = pd.DataFrame(dvh_csv_list).round(2)
     # Fill empty blocks with 0.0
     pddf.fillna(0.0, inplace=True)
-    pddf.set_index('Patient ID', inplace=True)
 
     # Return pandas dataframe
     return pddf

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -175,7 +175,7 @@ def dvh2pandas(dict_dvh, patient_id):
                 break
             if (dose[j] >= current_percentage_range):
                 cGy = str(j) + 'cGy: ' + str(dose[j])
-                current_cGy_list.append(cGy)
+                current_cGy_list.extend(cGy)
             else:
                 dvh_roi_list.append(current_cGy_list)
                 current_percentage_range -= 0.5                

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -175,6 +175,7 @@ def dvh2pandas(dict_dvh, patient_id):
             for centiGray in range(current_dose_index, len(dose), 10):
                 if dose[centiGray] == percent:
                     last_volume = centiGray
+                """
                 else:
                     if dose[centiGray] >= percent - 0.5:
                         current_dose_index = centiGray
@@ -185,6 +186,7 @@ def dvh2pandas(dict_dvh, patient_id):
                         drop_per = percent - dose[tempt_peak_dose_index]
                         substract_amount = drop_per/volume_drop_per * 10
                         last_volume = centiGray - substract_amount
+                """
             dvh_csv_list.append(str(last_volume) + 'cGy')
             
             

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -183,7 +183,7 @@ def dvh2pandas(dict_dvh, patient_id):
         csv_header.append(str(i) + '%')
 
     # Convert the list into pandas dataframe, with 2 digit rounding.
-    pddf = pd.DataFrame(dvh_csv_list, columns=csv_header).round(2)
+    pddf = pd.DataFrame(dvh_csv_list).round(2)
     # Fill empty blocks with 0.0
     pddf.fillna(0.0, inplace=True)
     pddf.set_index('Patient ID', inplace=True)

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -165,21 +165,14 @@ def dvh2pandas(dict_dvh, patient_id):
         dvh_roi_list.append(volume)
         dose = dvh.relative_volume.counts
 
-        current_cGy_list = ''
-        current_percentage_range = 100
-        for j in range(0, len(dose), 10):
-            if current_percentage_range < 0:
-                break
-            if dose[j] >= current_percentage_range:
-                cGy = '[' + str(j) + 'cGy: ' + str(dose[j].round(2)) + ']'
-                current_cGy_list += cGy
-            else:
-                dvh_roi_list.append(current_cGy_list)
-                current_percentage_range -= 0.5  
-                current_cGy_list = ''
-                cGy = '[' + str(j) + 'cGy: ' + str(dose[j].round(2)) + ']'
-                current_cGy_list += cGy                  
-
+        for m in np.arange(100, -0.5, -0.5):
+            current_cGy_list = ''
+            for n in range(0, len(dose), 10):
+                if dose[n] < m + 0.5 and dose[n] >= m:
+                    cGy = '[' + str(n) + 'cGy: ' + str(dose[n].round(2)) + ']'
+                    current_cGy_list += cGy
+            dvh_roi_list.append(current_cGy_list)  
+             
         dvh_csv_list.append(dvh_roi_list)
     
     #Column in percentage %
@@ -187,9 +180,10 @@ def dvh2pandas(dict_dvh, patient_id):
         csv_header.append(str(i) + '%')
 
     # Convert the list into pandas dataframe, with 2 digit rounding.
-    pddf = pd.DataFrame(dvh_csv_list).round(2)
+    pddf = pd.DataFrame(dvh_csv_list, columns=csv_header).round(2)
     # Fill empty blocks with 0.0
     pddf.fillna(0.0, inplace=True)
+    pddf.set_index('Patient ID', inplace=True)
 
     # Return pandas dataframe
     return pddf

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -150,31 +150,41 @@ def dvh2pandas(dict_dvh, patient_id):
     csv_header.append('ROI')
     csv_header.append('Volume (mL)')
 
-    max_roi_dose = 0
-
     dvh_csv_list = []
 
+    # DVH.CSV EXPORT
+    
+    #Row in centiGray cGy
     for i in dict_dvh:
         dvh_roi_list = []
+
         dvh = dict_dvh[i]
         name = dvh.name
         volume = dvh.volume
+
         dvh_roi_list.append(patient_id)
         dvh_roi_list.append(name)
         dvh_roi_list.append(volume)
+
         dose = dvh.relative_volume.counts
 
+        current_cGy_list = []
+        current_percentage_range = 100
         for i in range(0, len(dose), 10):
-            dvh_roi_list.append(dose[i])
-            # Update the maximum dose value, if current dose
-            # exceeds the current maximum dose
-            if i > max_roi_dose:
-                max_roi_dose = i
+            if (current_percentage_range < 0)
+                break
+            if (dose[i] >= current_percentage_range)
+                cGy = str(i) + 'cGy: ' + str(dose[0])
+                current_cGy_list.append(cGy)
+            else
+                dvh_roi_list.append(current_cGy_list)
+                current_percentage_range = current_percentage_range - 0.5                
 
         dvh_csv_list.append(dvh_roi_list)
-
-    for i in range(0, max_roi_dose + 1, 10):
-        csv_header.append(str(i) + 'cGy')
+    
+    #Column in percentage %
+    for i in np.arange(100, 0 - 0.5, -0.5):
+        csv_header.append(str(i) + '%')
 
     # Convert the list into pandas dataframe, with 2 digit rounding.
     pddf = pd.DataFrame(dvh_csv_list, columns=csv_header).round(2)

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -171,20 +171,22 @@ def dvh2pandas(dict_dvh, patient_id):
         current_dose_index = 0
         tempt_peak_dose_index = 0
         for percent in np.arange(100, -0.5, -0.5):
-            last_volume = 0
+            last_volume = -1
             for centiGray in range(current_dose_index, len(dose), 10):
                 if dose[centiGray] == percent:
                     last_volume = centiGray
+                '''
                 else:
                     if dose[centiGray] >= percent - 0.5:
-                        current_dose_index = centiGray
                         tempt_peak_dose_index = centiGray
-                        break
                     else:
                         volume_drop_per = 10 * (dose[tempt_peak_dose_index] - dose[centiGray])/(tempt_peak_dose_index - centiGray)
                         drop_per = percent - dose[tempt_peak_dose_index]
                         substract_amount = drop_per/volume_drop_per * 10
                         last_volume = centiGray - substract_amount
+                        
+                        current_dose_index = centiGray
+                '''
             dvh_roi_list.append(str(last_volume) + 'cGy')
         
         dvh_csv_list.append(dvh_roi_list)

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -168,11 +168,10 @@ def dvh2pandas(dict_dvh, patient_id):
         current_cGy_list = ''
         current_percentage_range = 100
         for j in range(0, len(dose), 10):
-            print(current_percentage_range)
             if current_percentage_range < 0:
                 break
-            elif dose[j] >= current_percentage_range:
-                cGy = '[' + str(j) + 'cGy: ' + str(dose[j]) + ']'
+            if dose[j] < current_percentage_range + 0.5 and dose[j] >= current_percentage_range:
+                cGy = '[' + str(j) + 'cGy: ' + str(dose[j].round(2)) + ']'
                 current_cGy_list += cGy
             else:
                 dvh_roi_list.append(current_cGy_list)
@@ -182,7 +181,7 @@ def dvh2pandas(dict_dvh, patient_id):
         dvh_csv_list.append(dvh_roi_list)
     
     #Column in percentage %
-    for i in np.arange(100, 0, -0.5):
+    for i in np.arange(100, -0.5, -0.5):
         csv_header.append(str(i) + '%')
 
     # Convert the list into pandas dataframe, with 2 digit rounding.

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -154,7 +154,29 @@ def dvh2pandas(dict_dvh, patient_id):
 
     # DVH.CSV EXPORT
     
-    
+    #Row in centiGray cGy
+    for i in dict_dvh:
+        dvh_roi_list = []
+
+        dvh = dict_dvh[i]
+        name = dvh.name
+        volume = dvh.volume
+
+        dvh_roi_list.append(patient_id)
+        dvh_roi_list.append(name)
+        dvh_roi_list.append(volume)
+
+        dose = dvh.relative_volume.counts
+
+        current_cGy_list = []
+        current_percentage_range = 100
+        for j in range(0, len(dose), 10):
+            if (current_percentage_range < 0):
+                break
+            if (dose[j] == current_percentage_range):
+                cGy = str(j) + 'cGy: '              
+
+        dvh_csv_list.append(dvh_roi_list)
     
     #Column in percentage %
     for i in np.arange(100, 0 - 0.5, -0.5):

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -175,14 +175,14 @@ def dvh2pandas(dict_dvh, patient_id):
                     last_volume = cgy
                 elif dose[cgy] > percent:
                     tempt_peak_dose_index = cgy
-                elif dose[cgy] < percent or cgy == len(dose) - 1:
-                    if last_volume == -1 and tempt_peak_dose_index != 0:
-                        volume_drop_per = 10 * (dose[tempt_peak_dose_index] - dose[cgy])/(tempt_peak_dose_index - cgy)
-                        drop_per = percent - dose[tempt_peak_dose_index]
-                        substract_amount = drop_per/volume_drop_per * 10
-                        last_volume = cgy - substract_amount
+                elif dose[cgy] < percent:
                     current_dose_index = cgy
                     break
+            if last_volume == -1 and tempt_peak_dose_index != 0:
+                volume_drop_per = 10 * (dose[tempt_peak_dose_index] - dose[cgy])/(tempt_peak_dose_index - cgy)
+                drop_per = percent - dose[tempt_peak_dose_index]
+                substract_amount = drop_per/volume_drop_per * 10
+                last_volume = cgy - substract_amount
             if last_volume != -1:
                 dvh_roi_list.append(str(round(last_volume // 1)) + 'cGy')
             else:

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -183,11 +183,11 @@ def dvh2pandas(dict_dvh, patient_id):
                     volume_per_drop = 10 * (dose[peak_i] - dose[trough_i])/(peak_i - trough_i)
                     per_drop = dose[peak_i] - percent
                     substract_amount = per_drop/volume_per_drop * 10
-                    last_volume = trough_i - substract_amount
+                    last_volume = peak_i - substract_amount
                 else:
-                    last_volume = dose[trough_i]
+                    last_volume = trough_i
             if last_volume != -1:
-                dvh_roi_list.append(str(last_volume // 1) + 'cGy')
+                dvh_roi_list.append(str(round(last_volume // 1)) + 'cGy')
             else:
                 dvh_roi_list.append('')
         dvh_csv_list.append(dvh_roi_list)

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -171,11 +171,12 @@ def dvh2pandas(dict_dvh, patient_id):
             if current_percentage_range < 0:
                 break
             if dose[j] >= current_percentage_range:
-                cGy = '[' + str(j) + 'cGy: ' + str(dose[j]) + ']'
+                cGy = '[' + str(j) + 'cGy: ' + str(dose[j]) ']'
                 current_cGy_list += cGy
             else:
                 dvh_roi_list.append(current_cGy_list)
-                current_percentage_range -= 0.5                    
+                current_percentage_range -= 0.5  
+                current_cGy_list = ''                  
 
         dvh_csv_list.append(dvh_roi_list)
     

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -168,6 +168,8 @@ def dvh2pandas(dict_dvh, patient_id):
         current_cGy_list = ''
         current_percentage_range = 100
         for j in range(0, len(dose), 10):
+            if current_percentage_range < -0.5:
+                break
             if dose[j] >= current_percentage_range:
                 cGy = '[' + str(j) + 'cGy: ' + str(dose[j]) + ']'
                 current_cGy_list += cGy
@@ -179,7 +181,7 @@ def dvh2pandas(dict_dvh, patient_id):
         dvh_csv_list.append(dvh_roi_list)
     
     #Column in percentage %
-    for i in np.arange(100, 0, -0.5):
+    for i in np.arange(100, -0.5, -0.5):
         csv_header.append(str(i) + '%')
 
     # Convert the list into pandas dataframe, with 2 digit rounding.

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -168,6 +168,8 @@ def dvh2pandas(dict_dvh, patient_id):
         current_cGy_list = ''
         current_percentage_range = 100
         for j in range(0, len(dose), 10):
+            if current_percentage_range < 0
+                break
             if dose[j] < current_percentage_range + 0.5 and dose[j] >= current_percentage_range:
                 cGy = '[' + str(j) + 'cGy: ' + str(dose[j].round(2)) + ']'
                 current_cGy_list += cGy

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -187,7 +187,7 @@ def dvh2pandas(dict_dvh, patient_id):
                 else:
                     last_volume = trough_i
             if last_volume != -1:
-                dvh_roi_list.append(str(round(last_volume)) + 'cGy')
+                dvh_roi_list.append(str(round(last_volume)))
             else:
                 dvh_roi_list.append('')
         dvh_csv_list.append(dvh_roi_list)

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -171,7 +171,7 @@ def dvh2pandas(dict_dvh, patient_id):
             if (current_percentage_range < 0):
                 break
             if (dose[j] >= current_percentage_range):
-                cGy = '[' + str(j) + 'cGy: ' + str(dose[j]) ']'
+                cGy = '[' + str(j) + 'cGy: ' + str(dose[j]) + ']'
                 current_cGy_list += cGy
             else:
                 dvh_roi_list.append(current_cGy_list)

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -179,7 +179,7 @@ def dvh2pandas(dict_dvh, patient_id):
         dvh_csv_list.append(dvh_roi_list)
     
     #Column in percentage %
-    for i in np.arange(100, 0 - 0.5, -0.5):
+    for i in np.arange(100, 0, -0.5):
         csv_header.append(str(i) + '%')
 
     # Convert the list into pandas dataframe, with 2 digit rounding.

--- a/src/Model/CalculateDVHs.py
+++ b/src/Model/CalculateDVHs.py
@@ -168,7 +168,7 @@ def dvh2pandas(dict_dvh, patient_id):
         current_cGy_list = ''
         current_percentage_range = 100
         for j in range(0, len(dose), 10):
-            if current_percentage_range < 0
+            if current_percentage_range < 0:
                 break
             if dose[j] < current_percentage_range + 0.5 and dose[j] >= current_percentage_range:
                 cGy = '[' + str(j) + 'cGy: ' + str(dose[j].round(2)) + ']'


### PR DESCRIPTION
The current DVH.CSV export has columns in 'centiGray' and rows in '%'.

Change output to columns in '%' (100%, 99.5%, 99.0%, .....) and rows in 'centiGray' (no decimals, normal rounding). This will produce a spreadsheet with a fixed number of columns irrespective of the prescribed radiation dose.