### PR TITLE
DICOM View Controller - Scrolling through CT layer + Drag and Drop CT image

### DIFF
--- a/src/View/mainpage/DicomView.py
+++ b/src/View/mainpage/DicomView.py
@@ -8,8 +8,7 @@ from src.Controller.PathHandler import data_path
 class CustomGraphicsView(QtWidgets.QGraphicsView):
     def __init__(self, parent=None):
         super().__init__(parent)
-    
-    self.setDragMode(QtWidgets.QGraphicsView.ScrollHandDrag)
+        self.setDragMode(QtWidgets.QGraphicsView.ScrollHandDrag)
 
     def wheelEvent(self, event: QtGui.QWheelEvent):
         modifiers = event.modifiers()

--- a/src/View/mainpage/DicomView.py
+++ b/src/View/mainpage/DicomView.py
@@ -5,6 +5,20 @@ from src.Model.PatientDictContainer import PatientDictContainer
 from src.constants import INITIAL_ONE_VIEW_ZOOM
 from src.Controller.PathHandler import data_path
 
+class CustomGraphicsView(QtWidgets.QGraphicsView):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+    def wheelEvent(self, event: QtGui.QWheelEvent):
+        modifiers = event.modifiers()
+        if modifiers == QtCore.Qt.ShiftModifier:
+            super().wheelEvent(event)
+        elif modifiers == QtCore.Qt.AltModifier:
+            super().wheelEvent(event)
+        elif modifiers == QtCore.Qt.ControlModifier:
+            event.ignore()
+        else:
+            event.ignore()
 
 class DicomView(QtWidgets.QWidget):
 
@@ -23,7 +37,7 @@ class DicomView(QtWidgets.QWidget):
         # Create components
         self.slider = QtWidgets.QSlider(QtCore.Qt.Vertical)
         self.init_slider()
-        self.view = QtWidgets.QGraphicsView()
+        self.view = CustomGraphicsView()
         self.init_view()
         self.scene = QtWidgets.QGraphicsScene()
 
@@ -53,6 +67,37 @@ class DicomView(QtWidgets.QWidget):
         background_brush = QtGui.QBrush(
             QtGui.QColor(0, 0, 0), QtCore.Qt.SolidPattern)
         self.view.setBackgroundBrush(background_brush)
+    
+    def wheelEvent(self, event: QtGui.QWheelEvent):
+        modifiers = event.modifiers()
+        if modifiers == QtCore.Qt.ShiftModifier:
+            super().wheelEvent(event)
+        elif modifiers == QtCore.Qt.AltModifier:
+            super().wheelEvent(event)
+        elif modifiers == QtCore.Qt.ControlModifier:
+            angle = event.angleDelta() / 8
+            delta = angle.y() / 15
+            if delta > 0:
+                self.zoom_in()
+            else:
+                self.zoom_out()
+        else:
+            num_degrees = event.angleDelta() / 8
+            num_steps = num_degrees / 15
+            delta = int(num_steps.y())
+            self.change_slice(delta)
+
+    def change_slice(self, delta):
+        current_value = self.slider.value()
+        new_value = current_value + delta
+
+        if new_value < self.slider.minimum():
+            new_value = self.slider.minimum()
+        elif new_value > self.slider.maximum():
+            new_value = self.slider.maximum()
+
+        self.slider.setValue(new_value)
+        self.value_changed()
 
     def value_changed(self):
         self.update_view()

--- a/src/View/mainpage/DicomView.py
+++ b/src/View/mainpage/DicomView.py
@@ -8,6 +8,8 @@ from src.Controller.PathHandler import data_path
 class CustomGraphicsView(QtWidgets.QGraphicsView):
     def __init__(self, parent=None):
         super().__init__(parent)
+    
+    self.setDragMode(QtWidgets.QGraphicsView.ScrollHandDrag)
 
     def wheelEvent(self, event: QtGui.QWheelEvent):
         modifiers = event.modifiers()

--- a/src/View/mainpage/DicomView.py
+++ b/src/View/mainpage/DicomView.py
@@ -70,21 +70,24 @@ class DicomView(QtWidgets.QWidget):
         self.view.setBackgroundBrush(background_brush)
     
     def wheelEvent(self, event: QtGui.QWheelEvent):
+        degree = 8
+        step = 15
+        #https://doc.qt.io/qt-6/qwheelevent.html#angleDelta
         modifiers = event.modifiers()
         if modifiers == QtCore.Qt.ShiftModifier:
             super().wheelEvent(event)
         elif modifiers == QtCore.Qt.AltModifier:
             super().wheelEvent(event)
         elif modifiers == QtCore.Qt.ControlModifier:
-            angle = event.angleDelta() / 8
-            delta = angle.y() / 15
+            angle = event.angleDelta() / degree
+            delta = angle.y() / step
             if delta > 0:
                 self.zoom_in()
             else:
                 self.zoom_out()
         else:
-            num_degrees = event.angleDelta() / 8
-            num_steps = num_degrees / 15
+            num_degrees = event.angleDelta() / degree
+            num_steps = num_degrees / step
             delta = int(num_steps.y())
             self.change_slice(delta)
 


### PR DESCRIPTION
1. Enable the scroll mouse / 2 finger scroll of the mouse tab scrolling through the CT layer (instead of up and down of a single CT picture)
2. Enable drag mode: Click the left mouse, then hold and drag to move the CT image