### PR TITLE
added RT Ion Plan SOP Class as one of the rtplan data types in the allowed_classes dictionary

### DIFF
--- a/src/Model/ImageLoading.py
+++ b/src/Model/ImageLoading.py
@@ -49,7 +49,7 @@ allowed_classes = {
         "name": "rtplan",
         "sliceable": False
     },
-    # RT Plan
+    # RT Ion Plan
     "1.2.840.10008.5.1.4.1.1.481.8": {
         "name": "rtplan",
         "sliceable": False

--- a/src/Model/ImageLoading.py
+++ b/src/Model/ImageLoading.py
@@ -49,6 +49,11 @@ allowed_classes = {
         "name": "rtplan",
         "sliceable": False
     },
+    # RT Plan
+    "1.2.840.10008.5.1.4.1.1.481.8": {
+        "name": "rtplan",
+        "sliceable": False
+    },
     # RT Image
     "1.2.840.10008.5.1.4.1.1.481.1": {
         "name": "rtimage",


### PR DESCRIPTION
added RT Ion Plan SOP Class as one of the rtplan data types in the allowed_classes dictionary
closes #264 