### PR TITLE
Fix 061dev1 bugs: Disable CT histogram, optimise coordinate map calculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ Hash_map.csv
 # Ignore compile results
 build/
 dist/
+.qodo
+
+# Ignore Apple specific files
+.DS_Store

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,3 +1,3 @@
 line-length = 88
 [format]
-quote-style = "single"
+quote-style = "double"

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,3 +1,3 @@
-line-length = 127
+line-length = 88
 [format]
 quote-style = "single"

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,3 @@
+line-length = 127
+[format]
+quote-style = "single"

--- a/src/Model/DICOM/DICOMDirectorySearch.py
+++ b/src/Model/DICOM/DICOMDirectorySearch.py
@@ -37,10 +37,10 @@ def get_dicom_structure(path, interrupt_flag, progress_callback):
     files_with_no_patient_id = 1
 
     for root, dirs, files in os.walk(path, topdown=True):
-        files = [f for f in files if not f[0] == '.']
-        dirs[:] = [d for d in dirs if not d[0] == '.']
+        files = [f for f in files if not f[0] == "."]
+        dirs[:] = [d for d in dirs if not d[0] == "."]
         for file in files:
-            if file[0] == '.':
+            if file[0] == ".":
                 break
             if interrupt_flag.is_set():
                 return
@@ -53,7 +53,7 @@ def get_dicom_structure(path, interrupt_flag, progress_callback):
             progress_callback.emit(files_searched)
 
             # Fix to program crashing when encountering DICOMDIR files
-            if file == 'DICOMDIR':
+            if file == "DICOMDIR":
                 continue
 
             file_path = root + os.sep + file
@@ -62,16 +62,16 @@ def get_dicom_structure(path, interrupt_flag, progress_callback):
             except (InvalidDicomError, FileNotFoundError, PermissionError):
                 pass
             else:
-                if 'PatientID' in dicom_file:
+                if "PatientID" in dicom_file:
                     patient_id = dicom_file.PatientID
                 else:
-                    patient_id = 'no_id_' + str(files_with_no_patient_id)
+                    patient_id = "no_id_" + str(files_with_no_patient_id)
                     files_with_no_patient_id += 1
 
                 if (
-                    'SOPInstanceUID' in dicom_file
-                    and 'SOPClassUID' in dicom_file
-                    and 'Modality' in dicom_file
+                    "SOPInstanceUID" in dicom_file
+                    and "SOPClassUID" in dicom_file
+                    and "Modality" in dicom_file
                 ):
                     new_image = Image(
                         file_path,
@@ -80,18 +80,18 @@ def get_dicom_structure(path, interrupt_flag, progress_callback):
                         dicom_file.Modality,
                     )
                     if not dicom_structure.has_patient(patient_id):
-                        if 'SeriesInstanceUID' not in dicom_file:
-                            logging.error('No SeriesInstanceUID found in %s', file_path)
+                        if "SeriesInstanceUID" not in dicom_file:
+                            logging.error("No SeriesInstanceUID found in %s", file_path)
                             continue
                         new_series = Series(dicom_file.SeriesInstanceUID)
                         new_series.series_description = dicom_file.get(
-                            'SeriesDescription'
+                            "SeriesDescription"
                         )
                         new_series.add_referenced_objects(dicom_file)
                         new_series.add_image(new_image)
 
                         new_study = Study(dicom_file.StudyInstanceUID)
-                        new_study.study_description = dicom_file.get('StudyDescription')
+                        new_study.study_description = dicom_file.get("StudyDescription")
                         new_study.add_series(new_series)
 
                         new_patient = Patient(patient_id, dicom_file.PatientName)
@@ -105,14 +105,14 @@ def get_dicom_structure(path, interrupt_flag, progress_callback):
                         if not existing_patient.has_study(dicom_file.StudyInstanceUID):
                             new_series = Series(dicom_file.SeriesInstanceUID)
                             new_series.series_description = dicom_file.get(
-                                'SeriesDescription'
+                                "SeriesDescription"
                             )
                             new_series.add_referenced_objects(dicom_file)
                             new_series.add_image(new_image)
 
                             new_study = Study(dicom_file.StudyInstanceUID)
                             new_study.study_description = dicom_file.get(
-                                'StudyDescription'
+                                "StudyDescription"
                             )
                             new_study.add_series(new_series)
 
@@ -126,7 +126,7 @@ def get_dicom_structure(path, interrupt_flag, progress_callback):
                             ):
                                 new_series = Series(dicom_file.SeriesInstanceUID)
                                 new_series.series_description = dicom_file.get(
-                                    'SeriesDescription'
+                                    "SeriesDescription"
                                 )
                                 new_series.add_referenced_objects(dicom_file)
                                 new_series.add_image(new_image)
@@ -140,7 +140,7 @@ def get_dicom_structure(path, interrupt_flag, progress_callback):
                                     dicom_file.SOPInstanceUID
                                 ):
                                     existing_series.series_description = dicom_file.get(
-                                        'SeriesDescription'
+                                        "SeriesDescription"
                                     )
                                     existing_series.add_image(new_image)
 

--- a/src/Model/ImageLoading.py
+++ b/src/Model/ImageLoading.py
@@ -33,58 +33,58 @@ from pydicom.errors import InvalidDicomError
 
 allowed_classes = {
     # CT Image
-    '1.2.840.10008.5.1.4.1.1.2': {
-        'name': 'ct',
-        'sliceable': True,
+    "1.2.840.10008.5.1.4.1.1.2": {
+        "name": "ct",
+        "sliceable": True,
     },
     # RT Structure Set
-    '1.2.840.10008.5.1.4.1.1.481.3': {
-        'name': 'rtss',
-        'sliceable': False,
+    "1.2.840.10008.5.1.4.1.1.481.3": {
+        "name": "rtss",
+        "sliceable": False,
     },
     # RT Dose
-    '1.2.840.10008.5.1.4.1.1.481.2': {
-        'name': 'rtdose',
-        'sliceable': False,
+    "1.2.840.10008.5.1.4.1.1.481.2": {
+        "name": "rtdose",
+        "sliceable": False,
     },
     # RT Plan
-    '1.2.840.10008.5.1.4.1.1.481.5': {
-        'name': 'rtplan',
-        'sliceable': False,
+    "1.2.840.10008.5.1.4.1.1.481.5": {
+        "name": "rtplan",
+        "sliceable": False,
     },
     # RT Ion Plan
-    '1.2.840.10008.5.1.4.1.1.481.8': {
-        'name': 'rtplan',
-        'sliceable': False,
+    "1.2.840.10008.5.1.4.1.1.481.8": {
+        "name": "rtplan",
+        "sliceable": False,
     },
     # RT Image
-    '1.2.840.10008.5.1.4.1.1.481.1': {
-        'name': 'rtimage',
-        'sliceable': False,
+    "1.2.840.10008.5.1.4.1.1.481.1": {
+        "name": "rtimage",
+        "sliceable": False,
     },
     # MR Image
-    '1.2.840.10008.5.1.4.1.1.4': {
-        'name': 'mr',
-        'sliceable': True,
+    "1.2.840.10008.5.1.4.1.1.4": {
+        "name": "mr",
+        "sliceable": True,
     },
     # PET Image
-    '1.2.840.10008.5.1.4.1.1.128': {
-        'name': 'pet',
-        'sliceable': True,
+    "1.2.840.10008.5.1.4.1.1.128": {
+        "name": "pet",
+        "sliceable": True,
     },
     # Comprehensive SR
-    '1.2.840.10008.5.1.4.1.1.88.33': {
-        'name': 'sr',
-        'sliceable': False,
+    "1.2.840.10008.5.1.4.1.1.88.33": {
+        "name": "sr",
+        "sliceable": False,
     },
     # CR Image
-    '1.2.840.10008.5.1.4.1.1.1': {
-        'name': 'cr',
-        'sliceable': True,
+    "1.2.840.10008.5.1.4.1.1.1": {
+        "name": "cr",
+        "sliceable": True,
     },
 }
 
-all_iods_required_attributes = ['StudyID']
+all_iods_required_attributes = ["StudyID"]
 
 iod_specific_required_attributes = {
     # # CT must have SliceLocation
@@ -154,29 +154,29 @@ def get_datasets(filepath_list, file_type=None):
                 is_missing = missing_interop_elements(read_file)
                 is_interoperable = len(is_missing) == 0
                 if not is_interoperable:
-                    missing_elements = ', '.join(is_missing)
-                    error_message = 'Interoperability failure:'
-                    error_message += f'<br>{file} '
-                    error_message += '<br>is missing ' + missing_elements
-                    error_message += f'<br>needed for SOP Class {read_file.SOPClassUID}'
+                    missing_elements = ", ".join(is_missing)
+                    error_message = "Interoperability failure:"
+                    error_message += f"<br>{file} "
+                    error_message += "<br>is missing " + missing_elements
+                    error_message += f"<br>needed for SOP Class {read_file.SOPClassUID}"
                     logging.error(error_message)
                     raise NotInteroperableWithOnkoDICOMError(error_message)
-                if allowed_class['sliceable']:
+                if allowed_class["sliceable"]:
                     slice_name = slice_count
                     slice_count += 1
                 else:
                     # Read from Series Description to determine what is
                     # stored in the SR file.
-                    if allowed_class['name'] == 'sr':
-                        if read_file.SeriesDescription == 'CLINICAL-DATA':
-                            slice_name = 'sr-cd'
-                        elif read_file.SeriesDescription == 'PYRADIOMICS':
-                            slice_name = 'sr-rad'
+                    if allowed_class["name"] == "sr":
+                        if read_file.SeriesDescription == "CLINICAL-DATA":
+                            slice_name = "sr-cd"
+                        elif read_file.SeriesDescription == "PYRADIOMICS":
+                            slice_name = "sr-rad"
                         else:
-                            slice_name = 'sr-other-' + str(sr_count)
+                            slice_name = "sr-other-" + str(sr_count)
                             sr_count += 1
                     else:
-                        slice_name = allowed_class['name']
+                        slice_name = allowed_class["name"]
 
                 if file_type is None or read_file.Modality == file_type:
                     read_data_dict[slice_name] = read_file
@@ -184,7 +184,9 @@ def get_datasets(filepath_list, file_type=None):
             else:
                 raise NotAllowedClassError
 
-    sorted_read_data_dict, sorted_file_names_dict = image_stack_sort(read_data_dict, file_names_dict)
+    sorted_read_data_dict, sorted_file_names_dict = image_stack_sort(
+        read_data_dict, file_names_dict
+    )
 
     return sorted_read_data_dict, sorted_file_names_dict
 
@@ -201,15 +203,23 @@ def missing_interop_elements(read_file) -> bool:
     """
     is_missing = []
     for onko_required_attribute in all_iods_required_attributes:
-        if not hasattr(read_file, onko_required_attribute) or read_file[onko_required_attribute].is_empty:
-            if onko_required_attribute == 'StudyID':
-                logging.warning(f'StudyID is missing from {read_file.filename}')
-                read_file['StudyID'] = 'MissingStudyID'
+        if (
+            not hasattr(read_file, onko_required_attribute)
+            or read_file[onko_required_attribute].is_empty
+        ):
+            if onko_required_attribute == "StudyID":
+                logging.warning(f"StudyID is missing from {read_file.filename}")
+                read_file["StudyID"] = "MissingStudyID"
                 continue
             is_missing.append(onko_required_attribute)
     if read_file.SOPClassUID in iod_specific_required_attributes:
-        for onko_required_attribute in iod_specific_required_attributes[read_file.SOPClassUID]:
-            if not hasattr(read_file, onko_required_attribute) or read_file[onko_required_attribute].is_empty:
+        for onko_required_attribute in iod_specific_required_attributes[
+            read_file.SOPClassUID
+        ]:
+            if (
+                not hasattr(read_file, onko_required_attribute)
+                or read_file[onko_required_attribute].is_empty
+            ):
                 is_missing.append(onko_required_attribute)
     return is_missing
 
@@ -253,7 +263,7 @@ def get_dict_sort_on_displacement(item):
     """
     img_dataset = item[1]
 
-    if img_dataset.Modality == 'CR':
+    if img_dataset.Modality == "CR":
         img_dataset = add_missing_cr_components(img_dataset)
 
     orientation = img_dataset.ImageOrientationPatient
@@ -262,9 +272,9 @@ def get_dict_sort_on_displacement(item):
     # SliceLocation is a type 3 attribute (optional), but it is relied upon elsewhere in OnkoDICOM
     # So if it isn't present, the displacement along the stack (in mm, rounded here to mm precision)
     #   is a reasonable value
-    if not hasattr(img_dataset, 'SliceLocation'):
-        slice_location = f'{round(sort_key)}'
-        elem = DataElement(0x00201041, 'DS', slice_location)
+    if not hasattr(img_dataset, "SliceLocation"):
+        slice_location = f"{round(sort_key)}"
+        elem = DataElement(0x00201041, "DS", slice_location)
         img_dataset.add(elem)
 
     return sort_key
@@ -276,9 +286,9 @@ def add_missing_cr_components(cr):
     :return: cr with required missing fields
     """
     cr_update = {
-        'ImageOrientationPatient': [1, 0, 0, 0, 0, 1],
-        'ImagePositionPatient': [0, 0, 0],
-        'SliceThickness': 1,
+        "ImageOrientationPatient": [1, 0, 0, 0, 0, 1],
+        "ImagePositionPatient": [0, 0, 0],
+        "SliceThickness": 1,
     }
     cr.update(cr_update)
 
@@ -292,13 +302,27 @@ def image_stack_sort(read_data_dict, file_names_dict):
     coordinate.
     :return: Tuple of sorted dictionaries
     """
-    new_image_dict = {key: value for (key, value) in read_data_dict.items() if str(key).isnumeric()}
-    new_image_file_names_dict = {key: value for (key, value) in file_names_dict.items() if str(key).isnumeric()}
-    new_non_image_dict = {key: value for (key, value) in read_data_dict.items() if not str(key).isnumeric()}
-    new_non_image_file_names_dict = {key: value for (key, value) in file_names_dict.items() if not str(key).isnumeric()}
+    new_image_dict = {
+        key: value for (key, value) in read_data_dict.items() if str(key).isnumeric()
+    }
+    new_image_file_names_dict = {
+        key: value for (key, value) in file_names_dict.items() if str(key).isnumeric()
+    }
+    new_non_image_dict = {
+        key: value
+        for (key, value) in read_data_dict.items()
+        if not str(key).isnumeric()
+    }
+    new_non_image_file_names_dict = {
+        key: value
+        for (key, value) in file_names_dict.items()
+        if not str(key).isnumeric()
+    }
 
     new_items = new_image_dict.items()
-    sorted_dict_on_displacement = sorted(new_items, key=get_dict_sort_on_displacement, reverse=True)
+    sorted_dict_on_displacement = sorted(
+        new_items, key=get_dict_sort_on_displacement, reverse=True
+    )
 
     new_read_data_dict = {}
     new_file_names_dict = {}
@@ -327,11 +351,11 @@ def is_dataset_dicom_rt(read_data_dict):
     class_names = []
 
     for key, item in read_data_dict.items():
-        if allowed_classes[item.SOPClassUID]['name'] not in class_names:
-            class_names.append(allowed_classes[item.SOPClassUID]['name'])
+        if allowed_classes[item.SOPClassUID]["name"] not in class_names:
+            class_names.append(allowed_classes[item.SOPClassUID]["name"])
 
     class_names.sort()
-    return class_names == ['ct', 'rtdose', 'rtplan', 'rtss']
+    return class_names == ["ct", "rtdose", "rtplan", "rtss"]
 
 
 def natural_sort(strings):
@@ -345,7 +369,7 @@ def natural_sort(strings):
         return int(text) if text.isdigit() else text.lower()
 
     def alphanum_key(key):
-        return [convert(c) for c in re.split('([0-9]+)', key)]
+        return [convert(c) for c in re.split("([0-9]+)", key)]
 
     return sorted(strings, key=alphanum_key)
 
@@ -358,9 +382,9 @@ def get_roi_info(dataset_rtss):
     dict_roi = {}
     for sequence in dataset_rtss.StructureSetROISequence:
         dict_temp = {}
-        dict_temp['uid'] = sequence.ReferencedFrameOfReferenceUID
-        dict_temp['name'] = sequence.ROIName
-        dict_temp['algorithm'] = sequence.ROIGenerationAlgorithm
+        dict_temp["uid"] = sequence.ReferencedFrameOfReferenceUID
+        dict_temp["name"] = sequence.ROIName
+        dict_temp["algorithm"] = sequence.ROIGenerationAlgorithm
         dict_roi[sequence.ROINumber] = dict_temp
 
     return dict_roi
@@ -384,7 +408,9 @@ def get_thickness_dict(dataset_rtss, read_data_dict):
         try:
             if len(contour.ContourSequence) == 1:
                 single_contour_rois[contour.ReferencedROINumber] = (
-                    contour.ContourSequence[0].ContourImageSequence[0].ReferencedSOPInstanceUID
+                    contour.ContourSequence[0]
+                    .ContourImageSequence[0]
+                    .ReferencedSOPInstanceUID
                 )
 
         except AttributeError:
@@ -401,8 +427,12 @@ def get_thickness_dict(dataset_rtss, read_data_dict):
 
         # Get the Image Position (Patient) from the two slices.
         try:
-            position_before = np.array(read_data_dict[slice_key - 1].ImagePositionPatient)
-            position_after = np.array(read_data_dict[slice_key + 1].ImagePositionPatient)
+            position_before = np.array(
+                read_data_dict[slice_key - 1].ImagePositionPatient
+            )
+            position_after = np.array(
+                read_data_dict[slice_key + 1].ImagePositionPatient
+            )
 
             # Calculate displacement between slices
             displacement = position_after - position_before
@@ -414,12 +444,20 @@ def get_thickness_dict(dataset_rtss, read_data_dict):
 
             # If the image slice is at the bottom of set.
             if slice_key == 1:
-                position_current = np.array(read_data_dict[slice_key].ImagePositionPatient)
-                position_after = np.array(read_data_dict[slice_key + 1].ImagePositionPatient)
+                position_current = np.array(
+                    read_data_dict[slice_key].ImagePositionPatient
+                )
+                position_after = np.array(
+                    read_data_dict[slice_key + 1].ImagePositionPatient
+                )
                 displacement = position_after - position_current
             elif slice_key > 0:
-                position_current = np.array(read_data_dict[slice_key].ImagePositionPatient)
-                position_before = np.array(read_data_dict[slice_key - 1].ImagePositionPatient)
+                position_current = np.array(
+                    read_data_dict[slice_key].ImagePositionPatient
+                )
+                position_before = np.array(
+                    read_data_dict[slice_key - 1].ImagePositionPatient
+                )
                 displacement = position_current - position_before
             else:
                 continue
@@ -427,7 +465,9 @@ def get_thickness_dict(dataset_rtss, read_data_dict):
         # Finally, calculate thickness.
         thickness = (
             math.sqrt(
-                displacement[0] * displacement[0] + displacement[1] * displacement[1] + displacement[2] * displacement[2]
+                displacement[0] * displacement[0]
+                + displacement[1] * displacement[1]
+                + displacement[2] * displacement[2]
             )
             / 2
         )
@@ -437,7 +477,9 @@ def get_thickness_dict(dataset_rtss, read_data_dict):
     return dict_thickness
 
 
-def calc_dvhs(dataset_rtss, dataset_rtdose, rois, dict_thickness, interrupt_flag, dose_limit=None):
+def calc_dvhs(
+    dataset_rtss, dataset_rtdose, rois, dict_thickness, interrupt_flag, dose_limit=None
+):
     """
     :param dataset_rtss: RTSTRUCT DICOM dataset object.
     :param dataset_rtdose: RTDOSE DICOM dataset object.
@@ -458,7 +500,9 @@ def calc_dvhs(dataset_rtss, dataset_rtdose, rois, dict_thickness, interrupt_flag
         thickness = None
         if roi in dict_thickness:
             thickness = dict_thickness[roi]
-        dict_dvh[roi] = dvhcalc.get_dvh(dataset_rtss, dataset_rtdose, roi, dose_limit, thickness=thickness)
+        dict_dvh[roi] = dvhcalc.get_dvh(
+            dataset_rtss, dataset_rtdose, roi, dose_limit, thickness=thickness
+        )
         if interrupt_flag.is_set():  # Stop calculating at the next DVH.
             return
 
@@ -530,7 +574,9 @@ def converge_to_0_dvh(raw_dvh):
                     tmp_bincenters.append(dvh.bincenters[-1] + i)
 
                 tmp_bincenters = np.array(tmp_bincenters)
-                tmp_bincenters = np.concatenate((dvh.bincenters.flatten(), tmp_bincenters))
+                tmp_bincenters = np.concatenate(
+                    (dvh.bincenters.flatten(), tmp_bincenters)
+                )
                 bincenters = np.array(tmp_bincenters)
                 counts = np.concatenate((dvh.counts.flatten(), np.array(zeros)))
 
@@ -542,8 +588,8 @@ def converge_to_0_dvh(raw_dvh):
             bincenters = dvh.bincenters
             counts = dvh.counts
 
-        res[roi]['bincenters'] = bincenters
-        res[roi]['counts'] = counts
+        res[roi]["bincenters"] = bincenters
+        res[roi]["counts"] = counts
 
     return res
 
@@ -567,11 +613,13 @@ def get_raw_contour_data(dataset_rtss):
         roi_name = dict_id[referenced_roi_number]
         dict_contour = collections.defaultdict(list)
         roi_points_count = 0
-        if 'ContourSequence' in roi:
+        if "ContourSequence" in roi:
             for roi_slice in roi.ContourSequence:
-                if 'ContourImageSequence' in roi_slice:
+                if "ContourImageSequence" in roi_slice:
                     for contour_img in roi_slice.ContourImageSequence:
-                        referenced_sop_instance_uid = contour_img.ReferencedSOPInstanceUID
+                        referenced_sop_instance_uid = (
+                            contour_img.ReferencedSOPInstanceUID
+                        )
                     contour_geometric_type = roi_slice.ContourGeometricType
                     number_of_contour_points = roi_slice.NumberOfContourPoints
                     roi_points_count += int(number_of_contour_points)
@@ -683,10 +731,10 @@ def get_pixluts(read_data_dict):
     :return: Dictionary of pixluts for the transformation from 3D to 2D.
     """
     dict_pixluts = {}
-    non_img_type = ['rtdose', 'rtplan', 'rtss', 'rtimage']
+    non_img_type = ["rtdose", "rtplan", "rtss", "rtimage"]
     for ds in read_data_dict:
         if ds not in non_img_type:
-            if isinstance(ds, str) and ds[0:3] == 'sr-':
+            if isinstance(ds, str) and ds[0:3] == "sr-":
                 continue
             else:
                 img_ds = read_data_dict[ds]
@@ -704,7 +752,7 @@ def get_image_uid_list(dataset):
     :return: uid_list, a list of SOPInstanceUIDs of all image slices of
         the patient
     """
-    non_img_list = ['rtss', 'rtdose', 'rtplan', 'rtimage']
+    non_img_list = ["rtss", "rtdose", "rtplan", "rtimage"]
     uid_list = []
 
     # Extract the SOPInstanceUID of every image (except RTSS, RTDOSE,
@@ -712,7 +760,7 @@ def get_image_uid_list(dataset):
     for key in dataset:
         if key not in non_img_list:
             if isinstance(key, str):
-                if key[0:3] != 'sr-':
+                if key[0:3] != "sr-":
                     uid_list.append(dataset[key].SOPInstanceUID)
             else:
                 uid_list.append(dataset[key].SOPInstanceUID)

--- a/src/Model/ImageLoading.py
+++ b/src/Model/ImageLoading.py
@@ -4,7 +4,7 @@ Format for allowed_classes:
 "SOPClassUID" : {
     "name" : string
     "sliceable" : bool,
-    "requires" : [SOPClassUID, ..]
+    "requires" : [SOPClassUID, ..],
 }
 
 Intention of this dictionary is that as SOP Classes are made compatible
@@ -18,6 +18,7 @@ function should not need to be added to. (Of course realistically this is
 not the case, however this alternative function promotes scalability and
 durability of the process).
 """
+
 import collections
 import logging
 import math
@@ -32,63 +33,64 @@ from pydicom.errors import InvalidDicomError
 
 allowed_classes = {
     # CT Image
-    "1.2.840.10008.5.1.4.1.1.2": {
-        "name": "ct",
-        "sliceable": True
+    '1.2.840.10008.5.1.4.1.1.2': {
+        'name': 'ct',
+        'sliceable': True,
     },
     # RT Structure Set
-    "1.2.840.10008.5.1.4.1.1.481.3": {
-        "name": "rtss",
-        "sliceable": False
+    '1.2.840.10008.5.1.4.1.1.481.3': {
+        'name': 'rtss',
+        'sliceable': False,
     },
     # RT Dose
-    "1.2.840.10008.5.1.4.1.1.481.2": {
-        "name": "rtdose",
-        "sliceable": False
+    '1.2.840.10008.5.1.4.1.1.481.2': {
+        'name': 'rtdose',
+        'sliceable': False,
     },
     # RT Plan
-    "1.2.840.10008.5.1.4.1.1.481.5": {
-        "name": "rtplan",
-        "sliceable": False
+    '1.2.840.10008.5.1.4.1.1.481.5': {
+        'name': 'rtplan',
+        'sliceable': False,
     },
     # RT Ion Plan
-    "1.2.840.10008.5.1.4.1.1.481.8": {
-        "name": "rtplan",
-        "sliceable": False
+    '1.2.840.10008.5.1.4.1.1.481.8': {
+        'name': 'rtplan',
+        'sliceable': False,
     },
     # RT Image
-    "1.2.840.10008.5.1.4.1.1.481.1": {
-        "name": "rtimage",
-        "sliceable": False
+    '1.2.840.10008.5.1.4.1.1.481.1': {
+        'name': 'rtimage',
+        'sliceable': False,
     },
     # MR Image
-    "1.2.840.10008.5.1.4.1.1.4": {
-        "name": "mr",
-        "sliceable": True
+    '1.2.840.10008.5.1.4.1.1.4': {
+        'name': 'mr',
+        'sliceable': True,
     },
     # PET Image
-    "1.2.840.10008.5.1.4.1.1.128": {
-        "name": "pet",
-        "sliceable": True
+    '1.2.840.10008.5.1.4.1.1.128': {
+        'name': 'pet',
+        'sliceable': True,
     },
     # Comprehensive SR
-    "1.2.840.10008.5.1.4.1.1.88.33": {
-        "name": "sr",
-        "sliceable": False
+    '1.2.840.10008.5.1.4.1.1.88.33': {
+        'name': 'sr',
+        'sliceable': False,
     },
     # CR Image
-    "1.2.840.10008.5.1.4.1.1.1": {
-        "name": "cr",
-        "sliceable": True
-    }
+    '1.2.840.10008.5.1.4.1.1.1': {
+        'name': 'cr',
+        'sliceable': True,
+    },
 }
 
-all_iods_required_attributes = [ "StudyID" ]
+all_iods_required_attributes = ['StudyID']
 
 iod_specific_required_attributes = {
     # # CT must have SliceLocation
     # "1.2.840.10008.5.1.4.1.1.2": [ "SliceLocation" ],
 }
+
 
 class NotRTSetError(Exception):
     """Error to indicate that the types of data required for the intended use are not present
@@ -96,6 +98,7 @@ class NotRTSetError(Exception):
     Args:
         Exception (_type_): _description_
     """
+
     pass
 
 
@@ -105,14 +108,16 @@ class NotAllowedClassError(Exception):
     Args:
         Exception (_type_): _description_
     """
+
     pass
+
 
 class NotInteroperableWithOnkoDICOMError(Exception):
     """OnkoDICOM requires certain DICOM elements/values that
-    are not DICOM Type 1 (required).  
-    For data that lack said elements (DICOM Type 3) 
+    are not DICOM Type 1 (required).
+    For data that lack said elements (DICOM Type 3)
     or lack values in those elements (DICOM Type 2)
-    raise an exception/error to indicate the data is lacking 
+    raise an exception/error to indicate the data is lacking
 
     Args:
         Exception (_type_): _description_
@@ -150,28 +155,28 @@ def get_datasets(filepath_list, file_type=None):
                 is_interoperable = len(is_missing) == 0
                 if not is_interoperable:
                     missing_elements = ', '.join(is_missing)
-                    error_message = "Interoperability failure:"
-                    error_message += f"<br>{file} "
-                    error_message += "<br>is missing " + missing_elements
-                    error_message += f"<br>needed for SOP Class {read_file.SOPClassUID}"
+                    error_message = 'Interoperability failure:'
+                    error_message += f'<br>{file} '
+                    error_message += '<br>is missing ' + missing_elements
+                    error_message += f'<br>needed for SOP Class {read_file.SOPClassUID}'
                     logging.error(error_message)
                     raise NotInteroperableWithOnkoDICOMError(error_message)
-                if allowed_class["sliceable"]:
+                if allowed_class['sliceable']:
                     slice_name = slice_count
                     slice_count += 1
                 else:
                     # Read from Series Description to determine what is
                     # stored in the SR file.
-                    if allowed_class["name"] == "sr":
-                        if read_file.SeriesDescription == "CLINICAL-DATA":
-                            slice_name = "sr-cd"
-                        elif read_file.SeriesDescription == "PYRADIOMICS":
-                            slice_name = "sr-rad"
+                    if allowed_class['name'] == 'sr':
+                        if read_file.SeriesDescription == 'CLINICAL-DATA':
+                            slice_name = 'sr-cd'
+                        elif read_file.SeriesDescription == 'PYRADIOMICS':
+                            slice_name = 'sr-rad'
                         else:
-                            slice_name = "sr-other-" + str(sr_count)
+                            slice_name = 'sr-other-' + str(sr_count)
                             sr_count += 1
                     else:
-                        slice_name = allowed_class["name"]
+                        slice_name = allowed_class['name']
 
                 if file_type is None or read_file.Modality == file_type:
                     read_data_dict[slice_name] = read_file
@@ -179,8 +184,7 @@ def get_datasets(filepath_list, file_type=None):
             else:
                 raise NotAllowedClassError
 
-    sorted_read_data_dict, sorted_file_names_dict = \
-        image_stack_sort(read_data_dict, file_names_dict)
+    sorted_read_data_dict, sorted_file_names_dict = image_stack_sort(read_data_dict, file_names_dict)
 
     return sorted_read_data_dict, sorted_file_names_dict
 
@@ -197,13 +201,15 @@ def missing_interop_elements(read_file) -> bool:
     """
     is_missing = []
     for onko_required_attribute in all_iods_required_attributes:
-        if (not hasattr(read_file, onko_required_attribute)
-            or read_file[onko_required_attribute].is_empty):
+        if not hasattr(read_file, onko_required_attribute) or read_file[onko_required_attribute].is_empty:
+            if onko_required_attribute == 'StudyID':
+                logging.warning(f'StudyID is missing from {read_file.filename}')
+                read_file['StudyID'] = 'MissingStudyID'
+                continue
             is_missing.append(onko_required_attribute)
     if read_file.SOPClassUID in iod_specific_required_attributes:
         for onko_required_attribute in iod_specific_required_attributes[read_file.SOPClassUID]:
-            if (not hasattr(read_file, onko_required_attribute)
-                            or read_file[onko_required_attribute].is_empty):
+            if not hasattr(read_file, onko_required_attribute) or read_file[onko_required_attribute].is_empty:
                 is_missing.append(onko_required_attribute)
     return is_missing
 
@@ -247,7 +253,7 @@ def get_dict_sort_on_displacement(item):
     """
     img_dataset = item[1]
 
-    if img_dataset.Modality == "CR":
+    if img_dataset.Modality == 'CR':
         img_dataset = add_missing_cr_components(img_dataset)
 
     orientation = img_dataset.ImageOrientationPatient
@@ -256,8 +262,8 @@ def get_dict_sort_on_displacement(item):
     # SliceLocation is a type 3 attribute (optional), but it is relied upon elsewhere in OnkoDICOM
     # So if it isn't present, the displacement along the stack (in mm, rounded here to mm precision)
     #   is a reasonable value
-    if not hasattr(img_dataset,"SliceLocation"):
-        slice_location = f"{round(sort_key)}"
+    if not hasattr(img_dataset, 'SliceLocation'):
+        slice_location = f'{round(sort_key)}'
         elem = DataElement(0x00201041, 'DS', slice_location)
         img_dataset.add(elem)
 
@@ -272,7 +278,7 @@ def add_missing_cr_components(cr):
     cr_update = {
         'ImageOrientationPatient': [1, 0, 0, 0, 0, 1],
         'ImagePositionPatient': [0, 0, 0],
-        'SliceThickness': 1
+        'SliceThickness': 1,
     }
     cr.update(cr_update)
 
@@ -286,22 +292,13 @@ def image_stack_sort(read_data_dict, file_names_dict):
     coordinate.
     :return: Tuple of sorted dictionaries
     """
-    new_image_dict = {key: value for (key, value)
-                      in read_data_dict.items()
-                      if str(key).isnumeric()}
-    new_image_file_names_dict = {key: value for (key, value)
-                                 in file_names_dict.items()
-                                 if str(key).isnumeric()}
-    new_non_image_dict = {key: value for (key, value)
-                          in read_data_dict.items()
-                          if not str(key).isnumeric()}
-    new_non_image_file_names_dict = {key: value for (key, value)
-                                     in file_names_dict.items()
-                                     if not str(key).isnumeric()}
+    new_image_dict = {key: value for (key, value) in read_data_dict.items() if str(key).isnumeric()}
+    new_image_file_names_dict = {key: value for (key, value) in file_names_dict.items() if str(key).isnumeric()}
+    new_non_image_dict = {key: value for (key, value) in read_data_dict.items() if not str(key).isnumeric()}
+    new_non_image_file_names_dict = {key: value for (key, value) in file_names_dict.items() if not str(key).isnumeric()}
 
     new_items = new_image_dict.items()
-    sorted_dict_on_displacement = sorted(
-        new_items, key=get_dict_sort_on_displacement, reverse=True)
+    sorted_dict_on_displacement = sorted(new_items, key=get_dict_sort_on_displacement, reverse=True)
 
     new_read_data_dict = {}
     new_file_names_dict = {}
@@ -330,11 +327,11 @@ def is_dataset_dicom_rt(read_data_dict):
     class_names = []
 
     for key, item in read_data_dict.items():
-        if allowed_classes[item.SOPClassUID]["name"] not in class_names:
-            class_names.append(allowed_classes[item.SOPClassUID]["name"])
+        if allowed_classes[item.SOPClassUID]['name'] not in class_names:
+            class_names.append(allowed_classes[item.SOPClassUID]['name'])
 
     class_names.sort()
-    return class_names == ["ct", "rtdose", "rtplan", "rtss"]
+    return class_names == ['ct', 'rtdose', 'rtplan', 'rtss']
 
 
 def natural_sort(strings):
@@ -386,9 +383,9 @@ def get_thickness_dict(dataset_rtss, read_data_dict):
     for contour in dataset_rtss.ROIContourSequence:
         try:
             if len(contour.ContourSequence) == 1:
-                single_contour_rois[contour.ReferencedROINumber] = \
-                    contour.ContourSequence[0].ContourImageSequence[0]. \
-                    ReferencedSOPInstanceUID
+                single_contour_rois[contour.ReferencedROINumber] = (
+                    contour.ContourSequence[0].ContourImageSequence[0].ReferencedSOPInstanceUID
+                )
 
         except AttributeError:
             pass
@@ -404,10 +401,8 @@ def get_thickness_dict(dataset_rtss, read_data_dict):
 
         # Get the Image Position (Patient) from the two slices.
         try:
-            position_before = np.array(
-                read_data_dict[slice_key - 1].ImagePositionPatient)
-            position_after = np.array(
-                read_data_dict[slice_key + 1].ImagePositionPatient)
+            position_before = np.array(read_data_dict[slice_key - 1].ImagePositionPatient)
+            position_after = np.array(read_data_dict[slice_key + 1].ImagePositionPatient)
 
             # Calculate displacement between slices
             displacement = position_after - position_before
@@ -419,32 +414,30 @@ def get_thickness_dict(dataset_rtss, read_data_dict):
 
             # If the image slice is at the bottom of set.
             if slice_key == 1:
-                position_current = np.array(
-                    read_data_dict[slice_key].ImagePositionPatient)
-                position_after = np.array(
-                    read_data_dict[slice_key + 1].ImagePositionPatient)
+                position_current = np.array(read_data_dict[slice_key].ImagePositionPatient)
+                position_after = np.array(read_data_dict[slice_key + 1].ImagePositionPatient)
                 displacement = position_after - position_current
             elif slice_key > 0:
-                position_current = np.array(
-                    read_data_dict[slice_key].ImagePositionPatient)
-                position_before = np.array(
-                    read_data_dict[slice_key - 1].ImagePositionPatient)
+                position_current = np.array(read_data_dict[slice_key].ImagePositionPatient)
+                position_before = np.array(read_data_dict[slice_key - 1].ImagePositionPatient)
                 displacement = position_current - position_before
             else:
                 continue
 
         # Finally, calculate thickness.
-        thickness = math.sqrt(displacement[0] * displacement[0]
-                              + displacement[1] * displacement[1]
-                              + displacement[2] * displacement[2]) / 2
+        thickness = (
+            math.sqrt(
+                displacement[0] * displacement[0] + displacement[1] * displacement[1] + displacement[2] * displacement[2]
+            )
+            / 2
+        )
 
         dict_thickness[roi_number] = thickness
 
     return dict_thickness
 
 
-def calc_dvhs(dataset_rtss, dataset_rtdose, rois, dict_thickness,
-              interrupt_flag, dose_limit=None):
+def calc_dvhs(dataset_rtss, dataset_rtdose, rois, dict_thickness, interrupt_flag, dose_limit=None):
     """
     :param dataset_rtss: RTSTRUCT DICOM dataset object.
     :param dataset_rtdose: RTDOSE DICOM dataset object.
@@ -465,8 +458,7 @@ def calc_dvhs(dataset_rtss, dataset_rtdose, rois, dict_thickness,
         thickness = None
         if roi in dict_thickness:
             thickness = dict_thickness[roi]
-        dict_dvh[roi] = dvhcalc.get_dvh(dataset_rtss, dataset_rtdose, roi,
-                                        dose_limit, thickness=thickness)
+        dict_dvh[roi] = dvhcalc.get_dvh(dataset_rtss, dataset_rtdose, roi, dose_limit, thickness=thickness)
         if interrupt_flag.is_set():  # Stop calculating at the next DVH.
             return
 
@@ -475,13 +467,11 @@ def calc_dvhs(dataset_rtss, dataset_rtdose, rois, dict_thickness,
 
 def calc_dvh_worker(rtss, dose, roi, queue, thickness, dose_limit=None):
     dvh = {}
-    dvh[roi] = \
-        dvhcalc.get_dvh(rtss, dose, roi, dose_limit, thickness=thickness)
+    dvh[roi] = dvhcalc.get_dvh(rtss, dose, roi, dose_limit, thickness=thickness)
     queue.put(dvh)
 
 
-def multi_calc_dvh(dataset_rtss, dataset_rtdose, rois, dict_thickness,
-                   dose_limit=None):
+def multi_calc_dvh(dataset_rtss, dataset_rtdose, rois, dict_thickness, dose_limit=None):
     """
     Multiprocessing variant of calc_dvh for fork-based platforms.
     """
@@ -497,9 +487,17 @@ def multi_calc_dvh(dataset_rtss, dataset_rtdose, rois, dict_thickness,
         thickness = None
         if roi_list[i] in dict_thickness:
             thickness = dict_thickness[roi_list[i]]
-        p = Process(target=calc_dvh_worker,
-                    args=(dataset_rtss, dataset_rtdose, roi_list[i],
-                          queue, thickness, dose_limit,))
+        p = Process(
+            target=calc_dvh_worker,
+            args=(
+                dataset_rtss,
+                dataset_rtdose,
+                roi_list[i],
+                queue,
+                thickness,
+                dose_limit,
+            ),
+        )
         processes.append(p)
         p.start()
 
@@ -532,11 +530,9 @@ def converge_to_0_dvh(raw_dvh):
                     tmp_bincenters.append(dvh.bincenters[-1] + i)
 
                 tmp_bincenters = np.array(tmp_bincenters)
-                tmp_bincenters = np.concatenate(
-                    (dvh.bincenters.flatten(), tmp_bincenters))
+                tmp_bincenters = np.concatenate((dvh.bincenters.flatten(), tmp_bincenters))
                 bincenters = np.array(tmp_bincenters)
-                counts = np.concatenate(
-                    (dvh.counts.flatten(), np.array(zeros)))
+                counts = np.concatenate((dvh.counts.flatten(), np.array(zeros)))
 
             # The last value of DVH is equal to 0
             else:
@@ -575,14 +571,12 @@ def get_raw_contour_data(dataset_rtss):
             for roi_slice in roi.ContourSequence:
                 if 'ContourImageSequence' in roi_slice:
                     for contour_img in roi_slice.ContourImageSequence:
-                        referenced_sop_instance_uid = \
-                            contour_img.ReferencedSOPInstanceUID
+                        referenced_sop_instance_uid = contour_img.ReferencedSOPInstanceUID
                     contour_geometric_type = roi_slice.ContourGeometricType
                     number_of_contour_points = roi_slice.NumberOfContourPoints
                     roi_points_count += int(number_of_contour_points)
                     contour_data = roi_slice.ContourData
-                    dict_contour[
-                        referenced_sop_instance_uid].append(contour_data)
+                    dict_contour[referenced_sop_instance_uid].append(contour_data)
         dict_roi[roi_name] = dict_contour
         dict_numpoints[roi_name] = roi_points_count
 
@@ -607,25 +601,80 @@ def calculate_matrix(img_ds):
     # Equation C.7.6.2.1-1.
     # https://dicom.innolitics.com/ciods/rt-structure-set/roi-contour/30060039/30060040/30060050
     matrix_m = np.matrix(
-        [[orientation[0] * dist_row, orientation[3] * dist_col, 0,
-          position[0]],
-         [orientation[1] * dist_row, orientation[4] * dist_col, 0,
-          position[1]],
-         [orientation[2] * dist_row, orientation[5] * dist_col, 0,
-          position[2]],
-         [0, 0, 0, 1]]
+        [
+            [orientation[0] * dist_row, orientation[3] * dist_col, 0, position[0]],
+            [orientation[1] * dist_row, orientation[4] * dist_col, 0, position[1]],
+            [orientation[2] * dist_row, orientation[5] * dist_col, 0, position[2]],
+            [0, 0, 0, 1],
+        ]
     )
-    x = []
-    y = []
-    for i in range(0, img_ds.Columns):
-        i_mat = matrix_m * np.matrix([[i], [0], [0], [1]])
-        x.append(float(i_mat[0]))
 
-    for j in range(0, img_ds.Rows):
-        j_mat = matrix_m * np.matrix([[0], [j], [0], [1]])
-        y.append(float(j_mat[1]))
+    # Optimization attempt: Pre-allocate arrays
+    # x = [None] * img_ds.Columns
+    # y = [None] * img_ds.Rows
+    # for i in range(img_ds.Columns):
+    #     i_mat = matrix_m * np.matrix([[i], [0], [0], [1]])
+    #     x[i] = float(i_mat[0])
 
-    return np.array(x), np.array(y)
+    # for j in range(img_ds.Rows):
+    #     j_mat = matrix_m * np.matrix([[0], [j], [0], [1]])
+    #     y[j] = float(j_mat[1])
+
+    # return np.array(x), np.array(y)
+
+    # Optimization attempt: avoid repeated matrix multiplications
+    # Calculate base values (origin)
+    origin = matrix_m * np.matrix([[0], [0], [0], [1]])
+
+    # Calculate increments (first column of matrix_m for x, second column for y)
+    x_increment = matrix_m[0, 0]  # First column, first row element
+    y_increment = matrix_m[1, 1]  # Second column, second row element
+
+    # # Create arrays efficiently
+    # x = np.array(
+    #     [float(origin[0]) + i * float(x_increment) for i in range(img_ds.Columns)]
+    # )
+    # y = np.array(
+    #     [float(origin[1]) + j * float(y_increment) for j in range(img_ds.Rows)]
+    # )
+
+    # return x, y
+
+    # Optimization attempt: avoid repeated matrix multiplications
+    # and repeated scalar multiplications
+    # Pre-allocate arrays
+    # x = np.empty(img_ds.Columns, dtype=np.float64)
+    # y = np.empty(img_ds.Rows, dtype=np.float64)
+
+    # # Set initial values
+    # x[0] = float(origin[0])
+    # y[0] = float(origin[1])
+
+    # # Fill arrays using cumulative addition
+    # for i in range(1, img_ds.Columns):
+    #     x[i] = x[i - 1] + x_increment
+
+    # for j in range(1, img_ds.Rows):
+    #     y[j] = y[j - 1] + y_increment
+
+    # return x, y
+
+    # Optimization attempt: Create arrays using vectorized operations
+    # x = np.arange(img_ds.Columns, dtype=np.float64) * x_increment + float(origin[0])
+    # y = np.arange(img_ds.Rows, dtype=np.float64) * y_increment + float(origin[1])
+
+    # return x, y
+
+    # Optimization attempt: use numpy to generate linearly spaced arrays in one go.
+    # Calculate end points
+    x_end = float(origin[0]) + (img_ds.Columns - 1) * x_increment
+    y_end = float(origin[1]) + (img_ds.Rows - 1) * y_increment
+
+    # Generate linearly spaced arrays in one operation
+    x = np.linspace(float(origin[0]), x_end, img_ds.Columns)
+    y = np.linspace(float(origin[1]), y_end, img_ds.Rows)
+
+    return x, y
 
 
 def get_pixluts(read_data_dict):

--- a/src/Model/ROI.py
+++ b/src/Model/ROI.py
@@ -1,35 +1,37 @@
 import collections
 import datetime
-import random
 import logging
+import random
 from copy import deepcopy
 from pathlib import Path
+
 import pydicom
+import numpy as np
 from alphashape import alphashape
-from pydicom.uid import generate_uid
 from pydicom import Dataset, Sequence
 from pydicom.dataset import FileMetaDataset, validate_file_meta
 from pydicom.tag import Tag
-from pydicom.uid import generate_uid, ImplicitVRLittleEndian
+from pydicom.uid import ImplicitVRLittleEndian, generate_uid
+from PySide6 import QtCore, QtGui
 from scipy.spatial.qhull import QhullError
-from shapely.geometry import Polygon, MultiPolygon, GeometryCollection
+from shapely.geometry import GeometryCollection, MultiPolygon, Polygon
 from shapely.validation import make_valid
 
-from src.Model.MovingDictContainer import MovingDictContainer
-from src.View.util.PatientDictContainerHelper import get_dict_slice_to_uid
 from src.constants import DEFAULT_WINDOW_SIZE
-from src.Model.CalculateImages import *
+from src.Model.MovingDictContainer import MovingDictContainer
+
 from src.Model.PatientDictContainer import PatientDictContainer
 from src.Model.Transform import inv_linear_transform
+from src.View.util.PatientDictContainerHelper import get_dict_slice_to_uid
 
 # Disable INFO logging of shapely
-logging.getLogger('shapely.geos').setLevel(logging.CRITICAL)
+logging.getLogger("shapely.geos").setLevel(logging.CRITICAL)
 
 # Dictionary of lambda functions for ROI Manipulation
 geometry_manipulation = {
-    'INTERSECTION': lambda geom_1, geom_2: geom_1.intersection(geom_2),
-    'UNION': lambda geom_1, geom_2: geom_1.union(geom_2),
-    'DIFFERENCE': lambda geom_1, geom_2: rois_difference(geom_1, geom_2)
+    "INTERSECTION": lambda geom_1, geom_2: geom_1.intersection(geom_2),
+    "UNION": lambda geom_1, geom_2: geom_1.union(geom_2),
+    "DIFFERENCE": lambda geom_1, geom_2: rois_difference(geom_1, geom_2),
 }
 
 
@@ -92,12 +94,12 @@ def delete_roi(rtss, roi_name):
 
 def add_to_roi(rtss, roi_name, roi_coordinates, data_set):
     """
-        Add new contour image sequence ROI to rtss
-        :param rtss: dataset of RTSS
-        :param roi_name: ROIName
-        :param roi_coordinates: Coordinates of pixels for new ROI
-        :param data_set: Data Set of selected DICOM image file
-        :return: rtss, with added ROI
+    Add new contour image sequence ROI to rtss
+    :param rtss: dataset of RTSS
+    :param roi_name: ROIName
+    :param roi_coordinates: Coordinates of pixels for new ROI
+    :param data_set: Data Set of selected DICOM image file
+    :return: rtss, with added ROI
     """
 
     # Creating a new ROIContourSequence, ContourSequence,
@@ -121,33 +123,27 @@ def add_to_roi(rtss, roi_name, roi_coordinates, data_set):
         if contour.ReferencedROINumber == existing_roi_number:
             position = index
 
-    new_contour_number = len(
-        rtss.ROIContourSequence[position].ContourSequence) + 1
+    new_contour_number = len(rtss.ROIContourSequence[position].ContourSequence) + 1
 
     # ROI Sequence
     for contour in contour_sequence:
         # if data_set.get("ReferencedImageSequence"):
-        contour.add_new(Tag("ContourImageSequence"),
-                        "SQ", contour_image_sequence)
+        contour.add_new(Tag("ContourImageSequence"), "SQ", contour_image_sequence)
 
         # Contour Sequence
         for contour_image in contour_image_sequence:
             # CT Image Storage
-            contour_image.add_new(Tag("ReferencedSOPClassUID"), "UI",
-                                  referenced_sop_class_uid)
-            contour_image.add_new(Tag("ReferencedSOPInstanceUID"), "UI",
-                                  referenced_sop_instance_uid)
+            contour_image.add_new(Tag("ReferencedSOPClassUID"), "UI", referenced_sop_class_uid)
+            contour_image.add_new(Tag("ReferencedSOPInstanceUID"), "UI", referenced_sop_instance_uid)
 
         contour.add_new(Tag("ContourNumber"), "IS", new_contour_number)
         if not _is_closed_contour(roi_coordinates):
             contour.add_new(Tag("ContourGeometricType"), "CS", "OPEN_PLANAR")
-            contour.add_new(Tag("NumberOfContourPoints"), "IS",
-                            number_of_contour_points)
+            contour.add_new(Tag("NumberOfContourPoints"), "IS", number_of_contour_points)
             contour.add_new(Tag("ContourData"), "DS", roi_coordinates)
         else:
             contour.add_new(Tag("ContourGeometricType"), "CS", "CLOSED_PLANAR")
-            contour.add_new(Tag("NumberOfContourPoints"), "IS",
-                            number_of_contour_points - 1)
+            contour.add_new(Tag("NumberOfContourPoints"), "IS", number_of_contour_points - 1)
             contour.add_new(Tag("ContourData"), "DS", roi_coordinates[0:-3])
 
     rtss.ROIContourSequence[position].ContourSequence.extend(contour_sequence)
@@ -155,8 +151,7 @@ def add_to_roi(rtss, roi_name, roi_coordinates, data_set):
     return rtss
 
 
-def create_roi(rtss, roi_name, roi_list,
-               rt_roi_interpreted_type="ORGAN", rtss_owner="PATIENT"):
+def create_roi(rtss, roi_name, roi_list, rt_roi_interpreted_type="ORGAN", rtss_owner="PATIENT"):
     """
     Create new contours of an ROI to rtss :param rtss: dataset of RTSS
     :param roi_name: ROIName :param roi_list: the list of contours to be
@@ -181,11 +176,10 @@ def create_roi(rtss, roi_name, roi_list,
         if value["name"] == roi_name:
             roi_exists = True
     for roi_info in roi_list:
-        data_set = roi_info['ds']
-        roi_coordinates = roi_info['coords']
+        data_set = roi_info["ds"]
+        roi_coordinates = roi_info["coords"]
         if not roi_exists:
-            rtss = add_new_roi(rtss, roi_name, roi_coordinates, data_set,
-                               rt_roi_interpreted_type)
+            rtss = add_new_roi(rtss, roi_name, roi_coordinates, data_set, rt_roi_interpreted_type)
             roi_exists = True
         else:
             # Add contour image data to existing ROI
@@ -194,8 +188,7 @@ def create_roi(rtss, roi_name, roi_list,
     return rtss
 
 
-def add_new_roi(rtss, roi_name, roi_coordinates, data_set,
-                rt_roi_interpreted_type):
+def add_new_roi(rtss, roi_name, roi_coordinates, data_set, rt_roi_interpreted_type):
     """
     Add the information of a new ROI to the rtss
     :param rtss: dataset of RTSS
@@ -215,10 +208,8 @@ def add_new_roi(rtss, roi_name, roi_coordinates, data_set,
         roi_number = 1
     else:
         first_roi_sequence = rtss["StructureSetROISequence"].value[0]
-        referenced_frame_of_reference_uid = \
-            first_roi_sequence.ReferencedFrameOfReferenceUID
-        roi_number = \
-            rtss["StructureSetROISequence"].value[-1].ROINumber + 1
+        referenced_frame_of_reference_uid = first_roi_sequence.ReferencedFrameOfReferenceUID
+        roi_number = rtss["StructureSetROISequence"].value[-1].ROINumber + 1
 
     # Colour TBC
     red = random.randint(0, 255)
@@ -232,16 +223,14 @@ def add_new_roi(rtss, roi_name, roi_coordinates, data_set,
     original_structure_set = rtss.StructureSetROISequence
 
     for structure_set in structure_set_sequence:
-        structure_set.add_new(Tag("ROINumber"), 'IS', roi_number)
-        structure_set.add_new(Tag("ReferencedFrameOfReferenceUID"), 'UI',
-                              referenced_frame_of_reference_uid)
-        structure_set.add_new(Tag("ROIName"), 'LO', roi_name)
-        structure_set.add_new(Tag("ROIGenerationAlgorithm"), 'CS', "")
+        structure_set.add_new(Tag("ROINumber"), "IS", roi_number)
+        structure_set.add_new(Tag("ReferencedFrameOfReferenceUID"), "UI", referenced_frame_of_reference_uid)
+        structure_set.add_new(Tag("ROIName"), "LO", roi_name)
+        structure_set.add_new(Tag("ROIGenerationAlgorithm"), "CS", "")
 
     # Combine old and new structure set
     original_structure_set.extend(structure_set_sequence)
-    rtss.add_new(Tag("StructureSetROISequence"), "SQ",
-                 original_structure_set)
+    rtss.add_new(Tag("StructureSetROISequence"), "SQ", original_structure_set)
 
     # Saving a new ROIContourSequence, ContourSequence,
     # ContourImageSequence
@@ -260,31 +249,22 @@ def add_new_roi(rtss, roi_name, roi_coordinates, data_set,
         # ROI Sequence
         for contour in contour_sequence:
             # if data_set.get("ReferencedImageSequence"):
-            contour.add_new(Tag("ContourImageSequence"), "SQ",
-                            contour_image_sequence)
+            contour.add_new(Tag("ContourImageSequence"), "SQ", contour_image_sequence)
 
             # Contour Sequence
             for contour_image in contour_image_sequence:
-                contour_image.add_new(
-                    Tag("ReferencedSOPClassUID"), "UI",
-                    referenced_sop_class_uid)  # CT Image Storage
-                contour_image.add_new(Tag("ReferencedSOPInstanceUID"),
-                                      "UI", referenced_sop_instance_uid)
+                contour_image.add_new(Tag("ReferencedSOPClassUID"), "UI", referenced_sop_class_uid)  # CT Image Storage
+                contour_image.add_new(Tag("ReferencedSOPInstanceUID"), "UI", referenced_sop_instance_uid)
 
             contour.add_new(Tag("ContourNumber"), "IS", 1)
             if not _is_closed_contour(roi_coordinates):
-                contour.add_new(Tag("ContourGeometricType"), "CS",
-                                "OPEN_PLANAR")
-                contour.add_new(Tag("NumberOfContourPoints"), "IS",
-                                number_of_contour_points)
+                contour.add_new(Tag("ContourGeometricType"), "CS", "OPEN_PLANAR")
+                contour.add_new(Tag("NumberOfContourPoints"), "IS", number_of_contour_points)
                 contour.add_new(Tag("ContourData"), "DS", roi_coordinates)
             else:
-                contour.add_new(Tag("ContourGeometricType"), "CS",
-                                "CLOSED_PLANAR")
-                contour.add_new(Tag("NumberOfContourPoints"), "IS",
-                                number_of_contour_points - 1)
-                contour.add_new(Tag("ContourData"), "DS",
-                                roi_coordinates[0:-3])
+                contour.add_new(Tag("ContourGeometricType"), "CS", "CLOSED_PLANAR")
+                contour.add_new(Tag("NumberOfContourPoints"), "IS", number_of_contour_points - 1)
+                contour.add_new(Tag("ContourData"), "DS", roi_coordinates[0:-3])
 
         roi_contour.add_new(Tag("ReferencedROINumber"), "IS", roi_number)
 
@@ -302,18 +282,13 @@ def add_new_roi(rtss, roi_name, roi_coordinates, data_set,
         # TODO: Check to make sure that there aren't multiple
         #  observations per ROI, e.g. increment from existing
         #  Observation Numbers?
-        ROI_observations.add_new(Tag("ObservationNumber"), 'IS',
-                                 roi_number)
-        ROI_observations.add_new(Tag("ReferencedROINumber"), 'IS',
-                                 roi_number)
-        ROI_observations.add_new(Tag("RTROIInterpretedType"), 'CS',
-                                 rt_roi_interpreted_type)
-        ROI_observations.add_new(Tag("ROIInterpreter"), 'CS',
-                                 "")
+        ROI_observations.add_new(Tag("ObservationNumber"), "IS", roi_number)
+        ROI_observations.add_new(Tag("ReferencedROINumber"), "IS", roi_number)
+        ROI_observations.add_new(Tag("RTROIInterpretedType"), "CS", rt_roi_interpreted_type)
+        ROI_observations.add_new(Tag("ROIInterpreter"), "CS", "")
 
     original_roi_observation_sequence.extend(rt_roi_observations_sequence)
-    rtss.add_new(Tag("RTROIObservationsSequence"), "SQ",
-                 original_roi_observation_sequence)
+    rtss.add_new(Tag("RTROIObservationsSequence"), "SQ", original_roi_observation_sequence)
     return rtss
 
 
@@ -357,8 +332,7 @@ def get_raw_contour_data(rtss):
         for roi_slice in roi.ContourSequence:
             referenced_sop_instance_uid = None
             for contour_img in roi_slice.ContourImageSequence:
-                referenced_sop_instance_uid = \
-                    contour_img.ReferencedSOPInstanceUID
+                referenced_sop_instance_uid = contour_img.ReferencedSOPInstanceUID
             number_of_contour_points = roi_slice.NumberOfContourPoints
             roi_points_count += int(number_of_contour_points)
             contour_data = roi_slice.ContourData
@@ -395,12 +369,9 @@ def calculate_matrix(img_ds):
         shape=(4, 4),
         buffer=np.array(
             [
-                [orientation[0] * dist_row, orientation[3] * dist_col, 0,
-                 position[0]],
-                [orientation[1] * dist_row, orientation[4] * dist_col, 0,
-                 position[1]],
-                [orientation[2] * dist_row, orientation[5] * dist_col, 0,
-                 position[2]],
+                [orientation[0] * dist_row, orientation[3] * dist_col, 0, position[0]],
+                [orientation[1] * dist_row, orientation[4] * dist_col, 0, position[1]],
+                [orientation[2] * dist_row, orientation[5] * dist_col, 0, position[2]],
                 [0, 0, 0, 1],
             ],
             dtype=float,
@@ -412,20 +383,14 @@ def calculate_matrix(img_ds):
     for i in range(0, img_ds.Columns):
         i_mat = np.matmul(
             matrix_m,
-            np.ndarray(
-                shape=(4, 1),
-                buffer=np.array([[i], [0], [0], [1]], dtype=float)
-            ),
+            np.ndarray(shape=(4, 1), buffer=np.array([[i], [0], [0], [1]], dtype=float)),
         )
         x.append(float(i_mat[0]))
 
     for j in range(0, img_ds.Rows):
         j_mat = np.matmul(
             matrix_m,
-            np.ndarray(
-                shape=(4, 1),
-                buffer=np.array([[0], [j], [0], [1]], dtype=float)
-            ),
+            np.ndarray(shape=(4, 1), buffer=np.array([[0], [j], [0], [1]], dtype=float)),
         )
         y.append(float(j_mat[1]))
 
@@ -442,7 +407,7 @@ def get_pixluts(dict_ds):
     non_img_type = ["rtdose", "rtplan", "rtss"]
     for ds in dict_ds:
         if ds not in non_img_type:
-            if isinstance(ds, str) and ds[0:3] == 'sr-':
+            if isinstance(ds, str) and ds[0:3] == "sr-":
                 continue
             else:
                 img_ds = dict_ds[ds]
@@ -542,21 +507,14 @@ def convert_hull_list_to_contours_data(rois_to_save, patient_dict_container):
     if rois_to_save == {}:
         return []
     for slice_id, slice_info in rois_to_save.items():
-        pixel_hull_list = slice_info['coords']
+        pixel_hull_list = slice_info["coords"]
         for pixel_hull in pixel_hull_list:
-            single_array = convert_hull_to_single_array_of_rcs(
-                patient_dict_container,
-                pixel_hull, slice_id
-            )
-            roi_list.append({
-                'ds': slice_info['ds'],
-                'coords': single_array
-            })
+            single_array = convert_hull_to_single_array_of_rcs(patient_dict_container, pixel_hull, slice_id)
+            roi_list.append({"ds": slice_info["ds"], "coords": single_array})
     return roi_list
 
 
-def convert_hull_to_single_array_of_rcs(patient_dict_container, pixel_hull,
-                                        slider_id):
+def convert_hull_to_single_array_of_rcs(patient_dict_container, pixel_hull, slider_id):
     """
     Convert border coordinate to contour data for one slice
     :param patient_dict_container: Dictionary container for
@@ -590,8 +548,7 @@ def convert_hull_to_rcs(patient_dict_container, hull_pts, slider_id):
 
     """
     dataset = patient_dict_container.dataset[slider_id]
-    pixlut = patient_dict_container.get("pixluts")[
-        dataset.SOPInstanceUID]
+    pixlut = patient_dict_container.get("pixluts")[dataset.SOPInstanceUID]
     z_coord = dataset.SliceLocation
     points = []
 
@@ -628,12 +585,12 @@ def pixel_to_rcs(pixlut, x, y):
 
 
 def get_contour_pixel(
-        dict_raw_contour_data,
-        roi_selected,
-        dict_pixluts,
-        curr_slice,
-        prone=False,
-        feetfirst=False,
+    dict_raw_contour_data,
+    roi_selected,
+    dict_pixluts,
+    curr_slice,
+    prone=False,
+    feetfirst=False,
 ):
     """
     Get pixels of contours of all rois selected within current slice.
@@ -655,9 +612,7 @@ def get_contour_pixel(
         raw_contours = dict_raw_contour_data[roi]
         number_of_contours = len(raw_contours[curr_slice])
         for i in range(number_of_contours):
-            contour_pixels = calculate_pixels(
-                pixlut, raw_contours[curr_slice][i], prone, feetfirst
-            )
+            contour_pixels = calculate_pixels(pixlut, raw_contours[curr_slice][i], prone, feetfirst)
             dict_pixels_of_roi[curr_slice].append(contour_pixels)
         dict_pixels[roi] = dict_pixels_of_roi
 
@@ -681,8 +636,7 @@ def get_roi_contour_pixel(dict_raw_contour_data, roi_list, dict_pixluts):
             pixlut = dict_pixluts[roi_slice]
             number_of_contours = len(raw_contour[roi_slice])
             for i in range(number_of_contours):
-                contour_pixels = calculate_pixels(pixlut,
-                                                  raw_contour[roi_slice][i])
+                contour_pixels = calculate_pixels(pixlut, raw_contour[roi_slice][i])
                 dict_pixels_of_roi[roi_slice].append(contour_pixels)
         dict_pixels[roi] = dict_pixels_of_roi
     return dict_pixels
@@ -690,10 +644,10 @@ def get_roi_contour_pixel(dict_raw_contour_data, roi_list, dict_pixluts):
 
 def transform_rois_contours(axial_rois_contours):
     """
-       Transform the axial ROI contours into coronal and sagittal
-       contours
-       :param axial_rois_contours: the dictionary of axial ROI contours
-       :return: Tuple of coronal and sagittal ROI contours
+    Transform the axial ROI contours into coronal and sagittal
+    contours
+    :param axial_rois_contours: the dictionary of axial ROI contours
+    :return: Tuple of coronal and sagittal ROI contours
     """
     coronal_rois_contours = {}
     sagittal_rois_contours = {}
@@ -706,25 +660,19 @@ def transform_rois_contours(axial_rois_contours):
             for contour in contours:
                 for i in range(len(contour)):
                     if contour[i][1] in coronal_rois_contours[name]:
-                        coronal_rois_contours[name][contour[i][1]][0] \
-                            .append([contour[i][0], slice_ids[slice_id]])
+                        coronal_rois_contours[name][contour[i][1]][0].append([contour[i][0], slice_ids[slice_id]])
                     else:
                         coronal_rois_contours[name][contour[i][1]] = [[]]
-                        coronal_rois_contours[name][contour[i][1]][0] \
-                            .append([contour[i][0], slice_ids[slice_id]])
+                        coronal_rois_contours[name][contour[i][1]][0].append([contour[i][0], slice_ids[slice_id]])
 
                     if contour[i][0] in sagittal_rois_contours[name]:
-                        sagittal_rois_contours[name][contour[i][0]][0] \
-                            .append([contour[i][1], slice_ids[slice_id]])
+                        sagittal_rois_contours[name][contour[i][0]][0].append([contour[i][1], slice_ids[slice_id]])
                     else:
                         sagittal_rois_contours[name][contour[i][0]] = [[]]
-                        sagittal_rois_contours[name][contour[i][0]][0] \
-                            .append([contour[i][1], slice_ids[slice_id]])
+                        sagittal_rois_contours[name][contour[i][0]][0].append([contour[i][1], slice_ids[slice_id]])
 
-    coronal_rois_contours = convert_coordinates_map_to_polygon_of_rois(
-        coronal_rois_contours)
-    sagittal_rois_contours = convert_coordinates_map_to_polygon_of_rois(
-        sagittal_rois_contours)
+    coronal_rois_contours = convert_coordinates_map_to_polygon_of_rois(coronal_rois_contours)
+    sagittal_rois_contours = convert_coordinates_map_to_polygon_of_rois(sagittal_rois_contours)
     return coronal_rois_contours, sagittal_rois_contours
 
 
@@ -749,15 +697,14 @@ def convert_coordinates_map_to_polygon_of_rois(contours_map):
 
 def calculate_concave_hull_of_points(pixel_coords, alpha=0.2):
     """
-        Return the alpha shape of the highlighted pixels using the alpha
-        entered by the user.
-        :param pixel_coords: the coordinates of the contour pixels
-        :return: List of lists of points ordered to form polygon(s).
-        """
+    Return the alpha shape of the highlighted pixels using the alpha
+    entered by the user.
+    :param pixel_coords: the coordinates of the contour pixels
+    :return: List of lists of points ordered to form polygon(s).
+    """
     # Get all the pixels in the drawing window's list of highlighted
     # pixels, excluding the removed pixels.
-    target_pixel_coords = [(item[0] + 1, item[1] + 1) for item in
-                           pixel_coords]
+    target_pixel_coords = [(item[0] + 1, item[1] + 1) for item in pixel_coords]
     # Calculate the concave hull of the points.
     # TODO: auto-generate an optimized alpha value
     # alpha = 0.95 * alphashape.optimizealpha(points)
@@ -770,7 +717,7 @@ def calculate_concave_hull_of_points(pixel_coords, alpha=0.2):
     if isinstance(hull, Polygon):
         polygon_list.append(hull_to_points(hull))
     elif isinstance(hull, MultiPolygon):
-        for polygon in hull:
+        for polygon in hull.geoms:
             polygon_list.append(hull_to_points(polygon))
     return polygon_list
 
@@ -789,8 +736,7 @@ def hull_to_points(hull):
     return points
 
 
-def calc_roi_polygon(curr_roi, curr_slice, dict_rois_contours,
-                     pixmap_aspect=1):
+def calc_roi_polygon(curr_roi, curr_slice, dict_rois_contours, pixmap_aspect=1):
     """
     Calculate a list of polygons to display for a given ROI and a given
     slice.
@@ -826,16 +772,14 @@ def calc_roi_polygon(curr_roi, curr_slice, dict_rois_contours,
     list_polygons = []
     pixel_list = dict_rois_contours[curr_roi][curr_slice]
     dataset = PatientDictContainer().dataset[0]
-    different_sizes = (dataset['Rows'].value != DEFAULT_WINDOW_SIZE)
+    different_sizes = dataset["Rows"].value != DEFAULT_WINDOW_SIZE
 
     if different_sizes:
         for i in range(len(pixel_list)):
             list_qpoints = []
             contour = pixel_list[i]
             for point in contour:
-                x_t, y_t = inv_linear_transform(
-                    point[0], point[1],
-                    dataset['Rows'].value, dataset['Columns'].value)
+                x_t, y_t = inv_linear_transform(point[0], point[1], dataset["Rows"].value, dataset["Columns"].value)
                 for x in x_t:
                     for y in y_t:
                         curr_qpoint = QtCore.QPoint(x, y * pixmap_aspect)
@@ -871,9 +815,9 @@ def ordered_list_rois(rois):
     return sorted(res)
 
 
-def create_initial_rtss_from_ct(img_ds: pydicom.dataset.Dataset,
-                                filepath: Path,
-                                uid_list: list) -> pydicom.dataset.FileDataset:
+def create_initial_rtss_from_ct(
+    img_ds: pydicom.dataset.Dataset, filepath: Path, uid_list: list
+) -> pydicom.dataset.FileDataset:
     """
     Pre-populate an RT Structure Set based on a single CT (or MR) and a
     list of image UIDs The caller should update the Structure Set Label,
@@ -910,48 +854,47 @@ def create_initial_rtss_from_ct(img_ds: pydicom.dataset.Dataset,
     # File Meta module
     file_meta = FileMetaDataset()
     file_meta.FileMetaInformationGroupLength = 238
-    file_meta.FileMetaInformationVersion = b'\x00\x01'
-    file_meta.MediaStorageSOPClassUID = '1.2.840.10008.5.1.4.1.1.481.3'
+    file_meta.FileMetaInformationVersion = b"\x00\x01"
+    file_meta.MediaStorageSOPClassUID = "1.2.840.10008.5.1.4.1.1.481.3"
     file_meta.MediaStorageSOPInstanceUID = generate_uid()
     file_meta.TransferSyntaxUID = ImplicitVRLittleEndian
     validate_file_meta(file_meta)
 
-    rt_ss = pydicom.dataset.FileDataset(filepath, {}, preamble=b"\0" * 128,
-                                        file_meta=file_meta)
+    rt_ss = pydicom.dataset.FileDataset(filepath, {}, preamble=b"\0" * 128, file_meta=file_meta)
     rt_ss.fix_meta_info()
 
-    top_level_tags_to_copy: list = [Tag("PatientName"),
-                                    Tag("PatientID"),
-                                    Tag("PatientBirthDate"),
-                                    Tag("PatientSex"),
-                                    Tag("StudyDate"),
-                                    Tag("StudyTime"),
-                                    Tag("AccessionNumber"),
-                                    Tag("ReferringPhysicianName"),
-                                    Tag("StudyDescription"),
-                                    Tag("StudyInstanceUID"),
-                                    Tag("StudyID"),
-                                    Tag("RequestingService"),
-                                    Tag("PatientAge"),
-                                    Tag("PatientSize"),
-                                    Tag("PatientWeight"),
-                                    Tag("MedicalAlerts"),
-                                    Tag("Allergies"),
-                                    Tag("PregnancyStatus"),
-                                    Tag("FrameOfReferenceUID"),
-                                    Tag("PositionReferenceIndicator"),
-                                    Tag("InstitutionName"),
-                                    Tag("InstitutionAddress"),
-                                    Tag("OperatorsName")
-                                    ]
+    top_level_tags_to_copy: list = [
+        Tag("PatientName"),
+        Tag("PatientID"),
+        Tag("PatientBirthDate"),
+        Tag("PatientSex"),
+        Tag("StudyDate"),
+        Tag("StudyTime"),
+        Tag("AccessionNumber"),
+        Tag("ReferringPhysicianName"),
+        Tag("StudyDescription"),
+        Tag("StudyInstanceUID"),
+        Tag("StudyID"),
+        Tag("RequestingService"),
+        Tag("PatientAge"),
+        Tag("PatientSize"),
+        Tag("PatientWeight"),
+        Tag("MedicalAlerts"),
+        Tag("Allergies"),
+        Tag("PregnancyStatus"),
+        Tag("FrameOfReferenceUID"),
+        Tag("PositionReferenceIndicator"),
+        Tag("InstitutionName"),
+        Tag("InstitutionAddress"),
+        Tag("OperatorsName"),
+    ]
 
     for tag in top_level_tags_to_copy:
         if tag in img_ds:
             rt_ss[tag] = deepcopy(img_ds[tag])
 
     if rt_ss.StudyInstanceUID == "":
-        raise ValueError(
-            "The given dataset is missing a required tag 'StudyInstanceUID'")
+        raise ValueError("The given dataset is missing a required tag 'StudyInstanceUID'")
 
     # RT Series Module
     rt_ss.SeriesDate = dicom_date
@@ -999,16 +942,13 @@ def create_initial_rtss_from_ct(img_ds: pydicom.dataset.Dataset,
     rt_referenced_study = pydicom.dataset.Dataset()
     rt_referenced_study.ReferencedSOPClassUID = "1.2.840.10008.3.1.2.3.1"
     rt_referenced_study.ReferencedSOPInstanceUID = img_ds.StudyInstanceUID
-    rt_referenced_study.RTReferencedSeriesSequence = \
-        rt_referenced_series_sequence
+    rt_referenced_study.RTReferencedSeriesSequence = rt_referenced_series_sequence
     rt_referenced_study_sequence = [rt_referenced_study]
 
     # RT Referenced Frame Of Reference Sequence, Structure Set Module
     referenced_frame_of_reference = pydicom.dataset.Dataset()
-    referenced_frame_of_reference.FrameOfReferenceUID = \
-        img_ds.FrameOfReferenceUID
-    referenced_frame_of_reference.RTReferencedStudySequence = \
-        rt_referenced_study_sequence
+    referenced_frame_of_reference.FrameOfReferenceUID = img_ds.FrameOfReferenceUID
+    referenced_frame_of_reference.RTReferencedStudySequence = rt_referenced_study_sequence
     rt_ss.ReferencedFrameOfReferenceSequence = [referenced_frame_of_reference]
 
     # Sequence modules
@@ -1055,8 +995,7 @@ def merge_rtss(old_rtss, new_rtss, duplicated_names):
         index += 1
 
     # Remove old values out of the original sequences
-    rm_indices = [old_duplicated_roi_indexes[name]
-                  for name in duplicated_names]
+    rm_indices = [old_duplicated_roi_indexes[name] for name in duplicated_names]
     for index in sorted(rm_indices, reverse=True):
         # Remove the old value out of the original structure set
         # sequence
@@ -1074,15 +1013,12 @@ def merge_rtss(old_rtss, new_rtss, duplicated_names):
     # Renumber the ROINumber and ReferencedROINumber tags
     original_structure_set = renumber_roi_number(original_structure_set)
     original_roi_contour = renumber_roi_number(original_roi_contour)
-    original_roi_observation_sequence = \
-        renumber_roi_number(original_roi_observation_sequence)
+    original_roi_observation_sequence = renumber_roi_number(original_roi_observation_sequence)
 
     # Set the new value
-    old_rtss.add_new(Tag("StructureSetROISequence"), "SQ",
-                     original_structure_set)
+    old_rtss.add_new(Tag("StructureSetROISequence"), "SQ", original_structure_set)
     old_rtss.add_new(Tag("ROIContourSequence"), "SQ", original_roi_contour)
-    old_rtss.add_new(Tag("RTROIObservationsSequence"), "SQ",
-                     original_roi_observation_sequence)
+    old_rtss.add_new(Tag("RTROIObservationsSequence"), "SQ", original_roi_observation_sequence)
 
     return old_rtss
 
@@ -1091,7 +1027,7 @@ def renumber_roi_number(sequence):
     roi_number = 1
     for item in sequence:
         if item.get("ROINumber") is not None:
-            item.add_new(Tag("ROINumber"), 'IS', str(roi_number))
+            item.add_new(Tag("ROINumber"), "IS", str(roi_number))
         elif item.get("ReferencedROINumber") is not None:
             item.add_new(Tag("ReferencedROINumber"), "IS", str(roi_number))
         roi_number += 1
@@ -1109,9 +1045,7 @@ def roi_to_geometry(dict_rois_contours):
 
     for slice_uid, contour_sequence in dict_rois_contours.items():
         # convert contour data to polygon omitting data with less than 3 points
-        polygon_list = [Polygon(contour_data)
-                        for contour_data in contour_sequence
-                        if len(contour_data) >= 3]
+        polygon_list = [Polygon(contour_data) for contour_data in contour_sequence if len(contour_data) >= 3]
         result_geometry = make_valid(MultiPolygon(polygon_list))
         dict_geometry[slice_uid] = result_geometry
 
@@ -1125,19 +1059,15 @@ def rois_difference(geom1, geom2):
     :param geom2: shapely Geometry
     :return: shapely Geometry
     """
-    if geom2.geom_type in ['MultiPolygon', 'GeometryCollection'] and \
-            not geom2.is_empty:
+    if geom2.geom_type in ["MultiPolygon", "GeometryCollection"] and not geom2.is_empty:
         inner_geoms = []
         other_geoms = []
         for sub_geometry in geom2:
-            if sub_geometry.geom_type == "Polygon" \
-                    and not sub_geometry.is_empty \
-                    and geom1.contains(sub_geometry):
+            if sub_geometry.geom_type == "Polygon" and not sub_geometry.is_empty and geom1.contains(sub_geometry):
                 inner_geoms.append(sub_geometry)
             elif sub_geometry.geom_type == "Polygon":
                 other_geoms.append(sub_geometry)
-        return add_rois(geom1.difference(MultiPolygon(other_geoms)),
-                        MultiPolygon(inner_geoms))
+        return add_rois(geom1.difference(MultiPolygon(other_geoms)), MultiPolygon(inner_geoms))
     elif geom1.contains(geom2):
         return add_rois(geom1, geom2)
     else:
@@ -1159,9 +1089,7 @@ def manipulate_rois(first_geometry_dict, second_geometry_dict, operation):
         first_geometry = first_geometry_dict.get(slice_uid, Polygon())
         second_geometry = second_geometry_dict.get(slice_uid, Polygon())
         try:
-            result_geometry_dict[slice_uid] = \
-                geometry_manipulation[operation](first_geometry,
-                                                 second_geometry)
+            result_geometry_dict[slice_uid] = geometry_manipulation[operation](first_geometry, second_geometry)
         except KeyError:
             raise Exception("Invalid operation string")
     return result_geometry_dict
@@ -1194,12 +1122,9 @@ def add_rois(geom1, geom2):
     :param geom2: Second geometry
     :return: GeometryCollection
     """
-    polygon_list = list([geom1]
-                        if geom1.geom_type == 'Polygon'
-                        else geom1) + \
-                   list([geom2]
-                        if geom2.geom_type == 'Polygon'
-                        else geom2)
+    polygon_list = list([geom1] if geom1.geom_type == "Polygon" else geom1) + list(
+        [geom2] if geom2.geom_type == "Polygon" else geom2
+    )
     return GeometryCollection(polygon_list)
 
 
@@ -1232,23 +1157,18 @@ def geometry_to_roi(geometry_dict):
     roi_contour_sequence = {}
     for slice_id, geometry in geometry_dict.items():
         contour_sequence = []
-        if geometry.geom_type == 'Polygon' and not geometry.is_empty:
-            contour_data = [list(map(int, coord))
-                            for coord in geometry.exterior.coords]
+        if geometry.geom_type == "Polygon" and not geometry.is_empty:
+            contour_data = [list(map(int, coord)) for coord in geometry.exterior.coords]
             contour_sequence.append(contour_data)
-        elif geometry.geom_type in ['MultiPolygon', 'GeometryCollection']:
+        elif geometry.geom_type in ["MultiPolygon", "GeometryCollection"]:
             for sub_geometry in geometry.geoms:
                 contour_data = []
-                if sub_geometry.geom_type == 'Polygon' \
-                        and not sub_geometry.is_empty:
-                    contour_data = [list(map(int, coord))
-                                    for coord in sub_geometry.exterior.coords]
+                if sub_geometry.geom_type == "Polygon" and not sub_geometry.is_empty:
+                    contour_data = [list(map(int, coord)) for coord in sub_geometry.exterior.coords]
                 # It is possible for MultiPolygon to be inside
                 # GeometryCollection
-                elif sub_geometry.geom_type == 'MultiPolygon':
-                    contour_data = [list(map(int, coord))
-                                    for polygon in sub_geometry
-                                    for coord in polygon.exterior.coords]
+                elif sub_geometry.geom_type == "MultiPolygon":
+                    contour_data = [list(map(int, coord)) for polygon in sub_geometry for coord in polygon.exterior.coords]
                 if contour_data:
                     contour_sequence.append(contour_data)
         if contour_sequence:

--- a/src/Model/ROI.py
+++ b/src/Model/ROI.py
@@ -717,8 +717,7 @@ def calculate_concave_hull_of_points(pixel_coords, alpha=0.2):
     if isinstance(hull, Polygon):
         polygon_list.append(hull_to_points(hull))
     elif isinstance(hull, MultiPolygon):
-        for polygon in hull.geoms:
-            polygon_list.append(hull_to_points(polygon))
+        polygon_list.extend(hull_to_points(polygon) for polygon in hull.geoms)
     return polygon_list
 
 

--- a/src/View/ImageLoader.py
+++ b/src/View/ImageLoader.py
@@ -6,7 +6,11 @@ from PySide6 import QtCore
 from pydicom import dcmread, dcmwrite
 
 from src.Model import ImageLoading
-from src.Model.CalculateDVHs import dvh2rtdose, rtdose2dvh, create_initial_rtdose_from_ct
+from src.Model.CalculateDVHs import (
+    dvh2rtdose,
+    rtdose2dvh,
+    create_initial_rtdose_from_ct,
+)
 from src.Model.PatientDictContainer import PatientDictContainer
 from src.Model.ROI import create_initial_rtss_from_ct
 from src.Model.xrRtstruct import create_initial_rtss_from_cr
@@ -38,11 +42,13 @@ class ImageLoader(QtCore.QObject):
         PatientDictContainer object containing all values related to the
         loaded DICOM files.
         """
-        progress_callback.emit(('Creating datasets...', 0))
+        progress_callback.emit(("Creating datasets...", 0))
         try:
             # Gets the common root folder.
             path = os.path.dirname(os.path.commonprefix(self.selected_files))
-            read_data_dict, file_names_dict = ImageLoading.get_datasets(self.selected_files)
+            read_data_dict, file_names_dict = ImageLoading.get_datasets(
+                self.selected_files
+            )
         except ImageLoading.NotAllowedClassError:
             raise ImageLoading.NotAllowedClassError
 
@@ -66,54 +72,58 @@ class ImageLoader(QtCore.QObject):
         # could come up with. If you have a cleaner alternative, please make
         # your contribution.
         if interrupt_flag.is_set():
-            print('stopped')
+            print("stopped")
             return False
 
-        if 'rtss' in file_names_dict:
-            dataset_rtss = dcmread(file_names_dict['rtss'])
+        if "rtss" in file_names_dict:
+            dataset_rtss = dcmread(file_names_dict["rtss"])
 
-            progress_callback.emit(('Getting ROI info...', 10))
+            progress_callback.emit(("Getting ROI info...", 10))
             rois = ImageLoading.get_roi_info(dataset_rtss)
 
             if interrupt_flag.is_set():  # Stop loading.
                 return False
 
-            progress_callback.emit(('Getting contour data...', 30))
-            dict_raw_contour_data, dict_numpoints = ImageLoading.get_raw_contour_data(dataset_rtss)
+            progress_callback.emit(("Getting contour data...", 30))
+            dict_raw_contour_data, dict_numpoints = ImageLoading.get_raw_contour_data(
+                dataset_rtss
+            )
 
             # Determine which ROIs are one slice thick
-            dict_thickness = ImageLoading.get_thickness_dict(dataset_rtss, read_data_dict)
+            dict_thickness = ImageLoading.get_thickness_dict(
+                dataset_rtss, read_data_dict
+            )
 
             if interrupt_flag.is_set():  # Stop loading.
                 return False
 
-            progress_callback.emit(('Getting pixel LUTs...', 50))
+            progress_callback.emit(("Getting pixel LUTs...", 50))
             dict_pixluts = ImageLoading.get_pixluts(read_data_dict)
-            progress_callback.emit(('Getting pixel LUTS...', 99))
+            progress_callback.emit(("Getting pixel LUTS...", 99))
             if interrupt_flag.is_set():  # Stop loading.
                 return False
 
-            progress_callback.emit(('Loading RTSS...', 1))
+            progress_callback.emit(("Loading RTSS...", 1))
             # Add RTSS values to PatientDictContainer
-            patient_dict_container.set('rois', rois)
-            patient_dict_container.set('raw_contour', dict_raw_contour_data)
-            patient_dict_container.set('num_points', dict_numpoints)
-            patient_dict_container.set('pixluts', dict_pixluts)
-            progress_callback.emit(('Loading RTSS...', 100))
-            if 'rtdose' not in file_names_dict:
-                progress_callback.emit(('Synthesizing RT Dose...', 1))
+            patient_dict_container.set("rois", rois)
+            patient_dict_container.set("raw_contour", dict_raw_contour_data)
+            patient_dict_container.set("num_points", dict_numpoints)
+            patient_dict_container.set("pixluts", dict_pixluts)
+            progress_callback.emit(("Loading RTSS...", 100))
+            if "rtdose" not in file_names_dict:
+                progress_callback.emit(("Synthesizing RT Dose...", 1))
                 self.load_temp_rtdose(path, progress_callback, interrupt_flag)
-                progress_callback.emit(('Synthesizing RT Dose...', 100))
+                progress_callback.emit(("Synthesizing RT Dose...", 100))
 
-            if 'rtdose' in file_names_dict:
+            if "rtdose" in file_names_dict:
                 # Check to see if DVH data exists in the RT Dose. If
                 # it is there, return (it will be populated later). If
                 # not, ask if the user wants it calculated.
                 try:
-                    progress_callback.emit(('Checking RT Dose for DVH data...', 1))
+                    progress_callback.emit(("Checking RT Dose for DVH data...", 1))
                     dvh_data = rtdose2dvh()
-                    progress_callback.emit(('Checking RT Dose for DVH data...', 100))
-                    if bool(dvh_data) and not dvh_data['diff']:
+                    progress_callback.emit(("Checking RT Dose for DVH data...", 100))
+                    if bool(dvh_data) and not dvh_data["diff"]:
                         return True
                 except KeyError:
                     pass
@@ -126,7 +136,7 @@ class ImageLoader(QtCore.QObject):
 
                 # Calculate DVHs
                 if self.calc_dvh:
-                    dataset_rtdose = dcmread(file_names_dict['rtdose'])
+                    dataset_rtdose = dcmread(file_names_dict["rtdose"])
 
                     # Spawn-based platforms (i.e Windows and MacOS) have
                     # a large overhead when creating a new process, which
@@ -134,27 +144,37 @@ class ImageLoader(QtCore.QObject):
                     # expensive than linear calculation. As such,
                     # multiprocessing is only available on Linux until a better
                     # solution is found.
-                    fork_safe_platforms = ['Linux']
+                    fork_safe_platforms = ["Linux"]
                     if platform.system() in fork_safe_platforms:
-                        progress_callback.emit(('Calculating DVHs...', 60))
-                        raw_dvh = ImageLoading.multi_calc_dvh(dataset_rtss, dataset_rtdose, rois, dict_thickness)
+                        progress_callback.emit(("Calculating DVHs...", 60))
+                        raw_dvh = ImageLoading.multi_calc_dvh(
+                            dataset_rtss, dataset_rtdose, rois, dict_thickness
+                        )
                     else:
-                        progress_callback.emit(('Calculating DVHs... (This may take a while)', 60))
-                        raw_dvh = ImageLoading.calc_dvhs(dataset_rtss, dataset_rtdose, rois, dict_thickness, interrupt_flag)
+                        progress_callback.emit(
+                            ("Calculating DVHs... (This may take a while)", 60)
+                        )
+                        raw_dvh = ImageLoading.calc_dvhs(
+                            dataset_rtss,
+                            dataset_rtdose,
+                            rois,
+                            dict_thickness,
+                            interrupt_flag,
+                        )
 
                     if interrupt_flag.is_set():  # Stop loading.
                         return False
 
-                    progress_callback.emit(('Converging to zero...', 80))
+                    progress_callback.emit(("Converging to zero...", 80))
                     dvh_x_y = ImageLoading.converge_to_0_dvh(raw_dvh)
 
                     if interrupt_flag.is_set():  # Stop loading.
                         return False
 
                     # Add DVH values to PatientDictContainer
-                    patient_dict_container.set('raw_dvh', raw_dvh)
-                    patient_dict_container.set('dvh_x_y', dvh_x_y)
-                    patient_dict_container.set('dvh_outdated', False)
+                    patient_dict_container.set("raw_dvh", raw_dvh)
+                    patient_dict_container.set("dvh_x_y", dvh_x_y)
+                    patient_dict_container.set("dvh_outdated", False)
 
                     # Write DVH data to the RT Dose
                     dvh2rtdose(raw_dvh)
@@ -175,43 +195,47 @@ class ImageLoader(QtCore.QObject):
         :param interrupt_flag: A threading.Event() object that tells the
         function to stop loading.
         """
-        progress_callback.emit(('Generating temporary rtss...', 20))
+        progress_callback.emit(("Generating temporary rtss...", 20))
         patient_dict_container = PatientDictContainer()
-        rtss_path = Path(path).joinpath('rtss.dcm')
+        rtss_path = Path(path).joinpath("rtss.dcm")
         uid_list = ImageLoading.get_image_uid_list(patient_dict_container.dataset)
 
-        if patient_dict_container.dataset[0].Modality == 'CR':
+        if patient_dict_container.dataset[0].Modality == "CR":
             # XR files
-            rtss = create_initial_rtss_from_cr(patient_dict_container.dataset[0], rtss_path, uid_list)
+            rtss = create_initial_rtss_from_cr(
+                patient_dict_container.dataset[0], rtss_path, uid_list
+            )
             # Code for saving the file automatically
             # rtss_path = patient_dict_container.filepaths[0] + "_XR-RTSTRUCT"
             # rtss.save_as(rtss_path)
         else:
-            rtss = create_initial_rtss_from_ct(patient_dict_container.dataset[0], rtss_path, uid_list)
+            rtss = create_initial_rtss_from_ct(
+                patient_dict_container.dataset[0], rtss_path, uid_list
+            )
 
         if interrupt_flag.is_set():  # Stop loading.
-            print('stopped')
+            print("stopped")
             return False
 
-        progress_callback.emit(('Loading temporary rtss...', 50))
+        progress_callback.emit(("Loading temporary rtss...", 50))
         # Set ROIs
         rois = ImageLoading.get_roi_info(rtss)
-        patient_dict_container.set('rois', rois)
+        patient_dict_container.set("rois", rois)
 
         # Set pixluts
         dict_pixluts = ImageLoading.get_pixluts(patient_dict_container.dataset)
-        patient_dict_container.set('pixluts', dict_pixluts)
+        patient_dict_container.set("pixluts", dict_pixluts)
 
         # Add RT Struct file path and dataset to patient dict container
-        patient_dict_container.filepaths['rtss'] = rtss_path
-        patient_dict_container.dataset['rtss'] = rtss
+        patient_dict_container.filepaths["rtss"] = rtss_path
+        patient_dict_container.dataset["rtss"] = rtss
 
         # Set some patient dict container attributes
-        patient_dict_container.set('file_rtss', rtss_path)
-        patient_dict_container.set('dataset_rtss', rtss)
+        patient_dict_container.set("file_rtss", rtss_path)
+        patient_dict_container.set("dataset_rtss", rtss)
         ordered_dict = DicomTree(None).dataset_to_dict(rtss)
-        patient_dict_container.set('dict_dicom_tree_rtss', ordered_dict)
-        patient_dict_container.set('selected_rois', [])
+        patient_dict_container.set("dict_dicom_tree_rtss", ordered_dict)
+        patient_dict_container.set("selected_rois", [])
 
     def load_temp_rtdose(self, path, progress_callback, interrupt_flag):
         """
@@ -223,22 +247,24 @@ class ImageLoader(QtCore.QObject):
         :param interrupt_flag: A threading.Event() object that tells the
         function to stop loading.
         """
-        progress_callback.emit(('Generating temporary rtdose...', 20))
+        progress_callback.emit(("Generating temporary rtdose...", 20))
         patient_dict_container = PatientDictContainer()
-        rtdose_path = Path(path).joinpath('rtdose.dcm')
-        if patient_dict_container.dataset[0].Modality == 'CR':
-            print('Unable to generate temporary RT Dose based on CR image')
+        rtdose_path = Path(path).joinpath("rtdose.dcm")
+        if patient_dict_container.dataset[0].Modality == "CR":
+            print("Unable to generate temporary RT Dose based on CR image")
             return False
 
         uid_list = ImageLoading.get_image_uid_list(patient_dict_container.dataset)
 
-        rtdose = create_initial_rtdose_from_ct(patient_dict_container.dataset[0], rtdose_path, uid_list)
+        rtdose = create_initial_rtdose_from_ct(
+            patient_dict_container.dataset[0], rtdose_path, uid_list
+        )
 
         if interrupt_flag.is_set():  # Stop loading.
-            print('stopped')
+            print("stopped")
             return False
 
-        progress_callback.emit(('Loading temporary rtdose...', 50))
+        progress_callback.emit(("Loading temporary rtdose...", 50))
         # Set ROIs
 
         # rois = ImageLoading.get_roi_info(rtdose)
@@ -246,19 +272,19 @@ class ImageLoader(QtCore.QObject):
 
         # Set pixluts
         dict_pixluts = ImageLoading.get_pixluts(patient_dict_container.dataset)
-        patient_dict_container.set('pixluts', dict_pixluts)
+        patient_dict_container.set("pixluts", dict_pixluts)
 
         # write the half baked RT Dose to file so future business logic will find it.
         dcmwrite(rtdose_path, rtdose, False)
         # Add RT Dose file path and dataset to patient dict container
-        patient_dict_container.filepaths['rtdose'] = rtdose_path
-        patient_dict_container.dataset['rtdose'] = rtdose
+        patient_dict_container.filepaths["rtdose"] = rtdose_path
+        patient_dict_container.dataset["rtdose"] = rtdose
 
         # Set some patient dict container attributes
-        patient_dict_container.set('file_rtdose', rtdose_path)
-        patient_dict_container.set('dataset_rtdose', rtdose)
+        patient_dict_container.set("file_rtdose", rtdose_path)
+        patient_dict_container.set("dataset_rtdose", rtdose)
         ordered_dict = DicomTree(None).dataset_to_dict(rtdose)
-        patient_dict_container.set('dict_dicom_tree_rtdose', ordered_dict)
+        patient_dict_container.set("dict_dicom_tree_rtdose", ordered_dict)
         # patient_dict_container.set("selected_rois", [])
 
     def update_calc_dvh(self, advice):

--- a/src/View/ImageLoader.py
+++ b/src/View/ImageLoader.py
@@ -22,8 +22,7 @@ class ImageLoader(QtCore.QObject):
 
     signal_request_calc_dvh = QtCore.Signal()
 
-    def __init__(self, selected_files, existing_rtss, parent_window,
-                 *args, **kwargs):
+    def __init__(self, selected_files, existing_rtss, parent_window, *args, **kwargs):
         super(ImageLoader, self).__init__(*args, **kwargs)
         self.selected_files = selected_files
         self.parent_window = parent_window
@@ -39,12 +38,11 @@ class ImageLoader(QtCore.QObject):
         PatientDictContainer object containing all values related to the
         loaded DICOM files.
         """
-        progress_callback.emit(("Creating datasets...", 0))
+        progress_callback.emit(('Creating datasets...', 0))
         try:
             # Gets the common root folder.
             path = os.path.dirname(os.path.commonprefix(self.selected_files))
-            read_data_dict, file_names_dict = ImageLoading.get_datasets(
-                self.selected_files)
+            read_data_dict, file_names_dict = ImageLoading.get_datasets(self.selected_files)
         except ImageLoading.NotAllowedClassError:
             raise ImageLoading.NotAllowedClassError
 
@@ -55,7 +53,7 @@ class ImageLoader(QtCore.QObject):
             path,
             read_data_dict,
             file_names_dict,
-            existing_rtss_files=self.existing_rtss
+            existing_rtss_files=self.existing_rtss,
         )
 
         # As there is no way to interrupt a QRunnable, this method must
@@ -68,57 +66,59 @@ class ImageLoader(QtCore.QObject):
         # could come up with. If you have a cleaner alternative, please make
         # your contribution.
         if interrupt_flag.is_set():
-            print("stopped")
+            print('stopped')
             return False
 
         if 'rtss' in file_names_dict:
             dataset_rtss = dcmread(file_names_dict['rtss'])
 
-            progress_callback.emit(("Getting ROI info...", 10))
+            progress_callback.emit(('Getting ROI info...', 10))
             rois = ImageLoading.get_roi_info(dataset_rtss)
 
             if interrupt_flag.is_set():  # Stop loading.
                 return False
 
-            progress_callback.emit(("Getting contour data...", 30))
-            dict_raw_contour_data, dict_numpoints = \
-                ImageLoading.get_raw_contour_data(dataset_rtss)
+            progress_callback.emit(('Getting contour data...', 30))
+            dict_raw_contour_data, dict_numpoints = ImageLoading.get_raw_contour_data(dataset_rtss)
 
             # Determine which ROIs are one slice thick
-            dict_thickness = ImageLoading.get_thickness_dict(
-                dataset_rtss, read_data_dict)
+            dict_thickness = ImageLoading.get_thickness_dict(dataset_rtss, read_data_dict)
 
             if interrupt_flag.is_set():  # Stop loading.
                 return False
 
-            progress_callback.emit(("Getting pixel LUTs...", 50))
+            progress_callback.emit(('Getting pixel LUTs...', 50))
             dict_pixluts = ImageLoading.get_pixluts(read_data_dict)
-
+            progress_callback.emit(('Getting pixel LUTS...', 99))
             if interrupt_flag.is_set():  # Stop loading.
                 return False
 
+            progress_callback.emit(('Loading RTSS...', 1))
             # Add RTSS values to PatientDictContainer
-            patient_dict_container.set("rois", rois)
-            patient_dict_container.set("raw_contour", dict_raw_contour_data)
-            patient_dict_container.set("num_points", dict_numpoints)
-            patient_dict_container.set("pixluts", dict_pixluts)
-
+            patient_dict_container.set('rois', rois)
+            patient_dict_container.set('raw_contour', dict_raw_contour_data)
+            patient_dict_container.set('num_points', dict_numpoints)
+            patient_dict_container.set('pixluts', dict_pixluts)
+            progress_callback.emit(('Loading RTSS...', 100))
             if 'rtdose' not in file_names_dict:
-                self.load_temp_rtdose(path,progress_callback,interrupt_flag)
+                progress_callback.emit(('Synthesizing RT Dose...', 1))
+                self.load_temp_rtdose(path, progress_callback, interrupt_flag)
+                progress_callback.emit(('Synthesizing RT Dose...', 100))
 
             if 'rtdose' in file_names_dict:
                 # Check to see if DVH data exists in the RT Dose. If
                 # it is there, return (it will be populated later). If
                 # not, ask if the user wants it calculated.
                 try:
+                    progress_callback.emit(('Checking RT Dose for DVH data...', 1))
                     dvh_data = rtdose2dvh()
-                    if bool(dvh_data) and not dvh_data["diff"]:
+                    progress_callback.emit(('Checking RT Dose for DVH data...', 100))
+                    if bool(dvh_data) and not dvh_data['diff']:
                         return True
                 except KeyError:
                     pass
 
-                self.parent_window.signal_advise_calc_dvh.connect(
-                    self.update_calc_dvh)
+                self.parent_window.signal_advise_calc_dvh.connect(self.update_calc_dvh)
                 self.signal_request_calc_dvh.emit()
 
                 while not self.advised_calc_dvh:
@@ -136,34 +136,25 @@ class ImageLoader(QtCore.QObject):
                     # solution is found.
                     fork_safe_platforms = ['Linux']
                     if platform.system() in fork_safe_platforms:
-                        progress_callback.emit(("Calculating DVHs...", 60))
-                        raw_dvh = \
-                            ImageLoading.multi_calc_dvh(dataset_rtss,
-                                                        dataset_rtdose, rois,
-                                                        dict_thickness)
+                        progress_callback.emit(('Calculating DVHs...', 60))
+                        raw_dvh = ImageLoading.multi_calc_dvh(dataset_rtss, dataset_rtdose, rois, dict_thickness)
                     else:
-                        progress_callback.emit(
-                            ("Calculating DVHs... (This may take a while)",
-                             60))
-                        raw_dvh = \
-                            ImageLoading.calc_dvhs(dataset_rtss,
-                                                   dataset_rtdose, rois,
-                                                   dict_thickness,
-                                                   interrupt_flag)
+                        progress_callback.emit(('Calculating DVHs... (This may take a while)', 60))
+                        raw_dvh = ImageLoading.calc_dvhs(dataset_rtss, dataset_rtdose, rois, dict_thickness, interrupt_flag)
 
                     if interrupt_flag.is_set():  # Stop loading.
                         return False
 
-                    progress_callback.emit(("Converging to zero...", 80))
+                    progress_callback.emit(('Converging to zero...', 80))
                     dvh_x_y = ImageLoading.converge_to_0_dvh(raw_dvh)
 
                     if interrupt_flag.is_set():  # Stop loading.
                         return False
 
                     # Add DVH values to PatientDictContainer
-                    patient_dict_container.set("raw_dvh", raw_dvh)
-                    patient_dict_container.set("dvh_x_y", dvh_x_y)
-                    patient_dict_container.set("dvh_outdated", False)
+                    patient_dict_container.set('raw_dvh', raw_dvh)
+                    patient_dict_container.set('dvh_x_y', dvh_x_y)
+                    patient_dict_container.set('dvh_outdated', False)
 
                     # Write DVH data to the RT Dose
                     dvh2rtdose(raw_dvh)
@@ -184,47 +175,43 @@ class ImageLoader(QtCore.QObject):
         :param interrupt_flag: A threading.Event() object that tells the
         function to stop loading.
         """
-        progress_callback.emit(("Generating temporary rtss...", 20))
+        progress_callback.emit(('Generating temporary rtss...', 20))
         patient_dict_container = PatientDictContainer()
         rtss_path = Path(path).joinpath('rtss.dcm')
-        uid_list = ImageLoading.get_image_uid_list(
-            patient_dict_container.dataset)
+        uid_list = ImageLoading.get_image_uid_list(patient_dict_container.dataset)
 
         if patient_dict_container.dataset[0].Modality == 'CR':
             # XR files
-            rtss = create_initial_rtss_from_cr(
-                patient_dict_container.dataset[0], rtss_path, uid_list)
+            rtss = create_initial_rtss_from_cr(patient_dict_container.dataset[0], rtss_path, uid_list)
             # Code for saving the file automatically
-            #rtss_path = patient_dict_container.filepaths[0] + "_XR-RTSTRUCT"
-            #rtss.save_as(rtss_path)
+            # rtss_path = patient_dict_container.filepaths[0] + "_XR-RTSTRUCT"
+            # rtss.save_as(rtss_path)
         else:
-            rtss = create_initial_rtss_from_ct(
-                patient_dict_container.dataset[0], rtss_path, uid_list)
+            rtss = create_initial_rtss_from_ct(patient_dict_container.dataset[0], rtss_path, uid_list)
 
         if interrupt_flag.is_set():  # Stop loading.
-            print("stopped")
+            print('stopped')
             return False
 
-        progress_callback.emit(("Loading temporary rtss...", 50))
+        progress_callback.emit(('Loading temporary rtss...', 50))
         # Set ROIs
         rois = ImageLoading.get_roi_info(rtss)
-        patient_dict_container.set("rois", rois)
+        patient_dict_container.set('rois', rois)
 
         # Set pixluts
         dict_pixluts = ImageLoading.get_pixluts(patient_dict_container.dataset)
-        patient_dict_container.set("pixluts", dict_pixluts)
+        patient_dict_container.set('pixluts', dict_pixluts)
 
         # Add RT Struct file path and dataset to patient dict container
         patient_dict_container.filepaths['rtss'] = rtss_path
         patient_dict_container.dataset['rtss'] = rtss
 
         # Set some patient dict container attributes
-        patient_dict_container.set("file_rtss", rtss_path)
-        patient_dict_container.set("dataset_rtss", rtss)
+        patient_dict_container.set('file_rtss', rtss_path)
+        patient_dict_container.set('dataset_rtss', rtss)
         ordered_dict = DicomTree(None).dataset_to_dict(rtss)
-        patient_dict_container.set("dict_dicom_tree_rtss", ordered_dict)
-        patient_dict_container.set("selected_rois", [])
-
+        patient_dict_container.set('dict_dicom_tree_rtss', ordered_dict)
+        patient_dict_container.set('selected_rois', [])
 
     def load_temp_rtdose(self, path, progress_callback, interrupt_flag):
         """
@@ -236,47 +223,43 @@ class ImageLoader(QtCore.QObject):
         :param interrupt_flag: A threading.Event() object that tells the
         function to stop loading.
         """
-        progress_callback.emit(("Generating temporary rtdose...", 20))
+        progress_callback.emit(('Generating temporary rtdose...', 20))
         patient_dict_container = PatientDictContainer()
         rtdose_path = Path(path).joinpath('rtdose.dcm')
         if patient_dict_container.dataset[0].Modality == 'CR':
-            print("Unable to generate temporary RT Dose based on CR image")
+            print('Unable to generate temporary RT Dose based on CR image')
             return False
-        
-        uid_list = ImageLoading.get_image_uid_list(
-            patient_dict_container.dataset)
 
-        
+        uid_list = ImageLoading.get_image_uid_list(patient_dict_container.dataset)
 
         rtdose = create_initial_rtdose_from_ct(patient_dict_container.dataset[0], rtdose_path, uid_list)
 
         if interrupt_flag.is_set():  # Stop loading.
-            print("stopped")
+            print('stopped')
             return False
 
-        progress_callback.emit(("Loading temporary rtdose...", 50))
+        progress_callback.emit(('Loading temporary rtdose...', 50))
         # Set ROIs
-        
+
         # rois = ImageLoading.get_roi_info(rtdose)
         # patient_dict_container.set("rois", rois)
 
         # Set pixluts
         dict_pixluts = ImageLoading.get_pixluts(patient_dict_container.dataset)
-        patient_dict_container.set("pixluts", dict_pixluts)
+        patient_dict_container.set('pixluts', dict_pixluts)
 
         # write the half baked RT Dose to file so future business logic will find it.
-        dcmwrite(rtdose_path,rtdose,False)
+        dcmwrite(rtdose_path, rtdose, False)
         # Add RT Dose file path and dataset to patient dict container
         patient_dict_container.filepaths['rtdose'] = rtdose_path
         patient_dict_container.dataset['rtdose'] = rtdose
 
         # Set some patient dict container attributes
-        patient_dict_container.set("file_rtdose", rtdose_path)
-        patient_dict_container.set("dataset_rtdose", rtdose)
+        patient_dict_container.set('file_rtdose', rtdose_path)
+        patient_dict_container.set('dataset_rtdose', rtdose)
         ordered_dict = DicomTree(None).dataset_to_dict(rtdose)
-        patient_dict_container.set("dict_dicom_tree_rtdose", ordered_dict)
+        patient_dict_container.set('dict_dicom_tree_rtdose', ordered_dict)
         # patient_dict_container.set("selected_rois", [])
-
 
     def update_calc_dvh(self, advice):
         self.advised_calc_dvh = True

--- a/src/View/mainpage/WindowingSlider.py
+++ b/src/View/mainpage/WindowingSlider.py
@@ -165,9 +165,7 @@ class WindowingSlider(QWidget):
         )
         if index < 0:
             return 0
-        if index >= self.slider_density:
-            return self.slider_density - 1
-        return index
+        return self.slider_density - 1 if index >= self.slider_density else index
 
     def window_to_index(self, val):
         """

--- a/src/View/mainpage/WindowingSlider.py
+++ b/src/View/mainpage/WindowingSlider.py
@@ -4,7 +4,13 @@ from contextlib import contextmanager
 from math import ceil
 
 from PySide6.QtWidgets import QWidget, QLabel, QApplication, QGridLayout, QSizePolicy
-from PySide6.QtCharts import QChart, QChartView, QLineSeries, QHorizontalBarSeries, QBarSet
+from PySide6.QtCharts import (
+    QChart,
+    QChartView,
+    QLineSeries,
+    QHorizontalBarSeries,
+    QBarSet,
+)
 from PySide6.QtGui import QCursor, QPixmap, QPainter, Qt
 from PySide6 import QtCore
 
@@ -59,7 +65,7 @@ class WindowingSlider(QWidget):
 
         self.set_dicom_view(dicom_view)
         patient_dict_container = PatientDictContainer()
-        self.pixel_values = patient_dict_container.get('pixel_values')
+        self.pixel_values = patient_dict_container.get("pixel_values")
 
         # Manage size of whole widget
         self.fixed_width = width
@@ -75,7 +81,9 @@ class WindowingSlider(QWidget):
         self.histogram_view.windowing_slider = self
         self.histogram = QChart()
         self.histogram_view.setChart(self.histogram)
-        self.histogram.setPlotArea(QtCore.QRectF(0, 0, self.fixed_width - 10, self.height()))
+        self.histogram.setPlotArea(
+            QtCore.QRectF(0, 0, self.fixed_width - 10, self.height())
+        )
 
         self.histogram_view.resize(self.fixed_width, self.height())
         self.histogram_view.setMouseTracking(True)
@@ -89,9 +97,9 @@ class WindowingSlider(QWidget):
         self.sliders.setLabelsVisible(False)
         self.slider_bars = []
         for i in range(0, self.slider_density):
-            self.slider_bars.append(QBarSet(''))
+            self.slider_bars.append(QBarSet(""))
             self.slider_bars[-1].append(1)
-            self.slider_bars[-1].setColor('white')
+            self.slider_bars[-1].setColor("white")
             self.sliders.append(self.slider_bars[-1])
         self.histogram.addSeries(self.sliders)
         self.histogram.zoom(2)  # at default zoom bars don't fill the chart
@@ -107,7 +115,7 @@ class WindowingSlider(QWidget):
         self.bottom = 0
 
         # Get the values for window and level from the dict
-        windowing_limits = patient_dict_container.get('dict_windowing')['Normal']
+        windowing_limits = patient_dict_container.get("dict_windowing")["Normal"]
 
         # Set window and level to the new values
         window = windowing_limits[0]
@@ -116,7 +124,7 @@ class WindowingSlider(QWidget):
 
         # Middle drag
         self.mouse_held = False
-        self.selected_bar = 'top'
+        self.selected_bar = "top"
         self.drag_start = 0
         self.drag_upper_limit = 0
         self.drag_lower_limit = 0
@@ -143,14 +151,18 @@ class WindowingSlider(QWidget):
         self.dicom_view.windowing_slider = self
 
     def resizeEvent(self, event):
-        self.histogram.setPlotArea(QtCore.QRectF(0, 0, self.fixed_width - 10, event.size().height()))
+        self.histogram.setPlotArea(
+            QtCore.QRectF(0, 0, self.fixed_width - 10, event.size().height())
+        )
 
     def height_to_index(self, pos):
         """
         Converts graph coordinates to a slider index
         :param pos: a local coordinate on the graph
         """
-        index = self.slider_density - 1 - int(pos / (self.height() / self.slider_density))
+        index = (
+            self.slider_density - 1 - int(pos / (self.height() / self.slider_density))
+        )
         if index < 0:
             return 0
         if index >= self.slider_density:
@@ -195,7 +207,7 @@ class WindowingSlider(QWidget):
         """
         self.histogram.removeSeries(self.density)
         self.density = QLineSeries()
-        self.density.setColor('grey')
+        self.density.setColor("grey")
         for i in range(0, len(densities)):
             self.density.append(2 - densities[i], i)
         self.histogram.addSeries(self.density)
@@ -256,15 +268,19 @@ class WindowingSlider(QWidget):
         index = min(index, self.slider_density - 1)
 
         if top_bar:
-            self.slider_bars[self.top].setColor('white')
+            self.slider_bars[self.top].setColor("white")
             self.top = index
-            self.slider_bars[index].setColor('red')
+            self.slider_bars[index].setColor("red")
         else:
             # Ensure the bottom bar is actually rendered
             # Functionally the bar will still be correct
-            self.slider_bars[max(self.bottom, WindowingSlider.MIN_BOTTOM_INDEX)].setColor('white')
+            self.slider_bars[
+                max(self.bottom, WindowingSlider.MIN_BOTTOM_INDEX)
+            ].setColor("white")
             self.bottom = index
-            self.slider_bars[max(index, WindowingSlider.MIN_BOTTOM_INDEX)].setColor('red')
+            self.slider_bars[max(index, WindowingSlider.MIN_BOTTOM_INDEX)].setColor(
+                "red"
+            )
 
     def set_bars(self, top_index, bottom_index):
         """
@@ -292,7 +308,7 @@ class WindowingSlider(QWidget):
         if min_dist > WindowingSlider.MAX_CLICK_DIST:
             # Check for middle drag
             if index - self.top > 0 or index - self.bottom > 0:
-                self.selected_bar = 'middle'
+                self.selected_bar = "middle"
                 self.mouse_held = True
                 self.drag_start = index
                 self.drag_upper_limit = self.slider_density - self.top
@@ -303,9 +319,9 @@ class WindowingSlider(QWidget):
 
         self.mouse_held = True
         if dist_to_top < dist_to_bottom:
-            self.selected_bar = 'top'
+            self.selected_bar = "top"
         else:
-            self.selected_bar = 'bottom'
+            self.selected_bar = "bottom"
 
     def mouse_move(self, event):
         """
@@ -353,11 +369,11 @@ class WindowingSlider(QWidget):
     def update_bar_position(self, event):
         # move selected bar to the closest valid position
         index = int(self.height_to_index(event.position().y()))
-        if self.selected_bar == 'top':
+        if self.selected_bar == "top":
             if index <= self.bottom:
                 index = self.bottom + 1
             self.update_bar(index, top_bar=True)
-        elif self.selected_bar == 'bottom':
+        elif self.selected_bar == "bottom":
             if index >= self.top:
                 index = self.top - 1
             self.update_bar(index, top_bar=False)

--- a/src/View/mainpage/WindowingSlider.py
+++ b/src/View/mainpage/WindowingSlider.py
@@ -11,9 +11,10 @@ from PySide6 import QtCore
 from src.Model.PatientDictContainer import PatientDictContainer
 from src.Model.Windowing import windowing_model_direct, set_windowing_slider
 
+
 @contextmanager
 def wait_cursor():
-    """context for wrapping a long running function 
+    """context for wrapping a long running function
     with wait_cursor():
         # do lengthy process
         pass
@@ -23,6 +24,7 @@ def wait_cursor():
         yield
     finally:
         QApplication.restoreOverrideCursor()
+
 
 class WindowingSlider(QWidget):
     """
@@ -49,7 +51,7 @@ class WindowingSlider(QWidget):
         :param width: the fixed width of the widget
         """
 
-        super(WindowingSlider,self).__init__()
+        super(WindowingSlider, self).__init__()
         self.action_handler = None
         if WindowingSlider.SINGLETON is None:
             WindowingSlider.SINGLETON = self
@@ -57,7 +59,7 @@ class WindowingSlider(QWidget):
 
         self.set_dicom_view(dicom_view)
         patient_dict_container = PatientDictContainer()
-        self.pixel_values = patient_dict_container.get("pixel_values")
+        self.pixel_values = patient_dict_container.get('pixel_values')
 
         # Manage size of whole widget
         self.fixed_width = width
@@ -73,8 +75,7 @@ class WindowingSlider(QWidget):
         self.histogram_view.windowing_slider = self
         self.histogram = QChart()
         self.histogram_view.setChart(self.histogram)
-        self.histogram.setPlotArea(
-            QtCore.QRectF(0, 0, self.fixed_width-10, self.height()))
+        self.histogram.setPlotArea(QtCore.QRectF(0, 0, self.fixed_width - 10, self.height()))
 
         self.histogram_view.resize(self.fixed_width, self.height())
         self.histogram_view.setMouseTracking(True)
@@ -88,9 +89,9 @@ class WindowingSlider(QWidget):
         self.sliders.setLabelsVisible(False)
         self.slider_bars = []
         for i in range(0, self.slider_density):
-            self.slider_bars.append(QBarSet(""))
+            self.slider_bars.append(QBarSet(''))
             self.slider_bars[-1].append(1)
-            self.slider_bars[-1].setColor("white")
+            self.slider_bars[-1].setColor('white')
             self.sliders.append(self.slider_bars[-1])
         self.histogram.addSeries(self.sliders)
         self.histogram.zoom(2)  # at default zoom bars don't fill the chart
@@ -106,7 +107,7 @@ class WindowingSlider(QWidget):
         self.bottom = 0
 
         # Get the values for window and level from the dict
-        windowing_limits = patient_dict_container.get("dict_windowing")['Normal']
+        windowing_limits = patient_dict_container.get('dict_windowing')['Normal']
 
         # Set window and level to the new values
         window = windowing_limits[0]
@@ -115,7 +116,7 @@ class WindowingSlider(QWidget):
 
         # Middle drag
         self.mouse_held = False
-        self.selected_bar = "top"
+        self.selected_bar = 'top'
         self.drag_start = 0
         self.drag_upper_limit = 0
         self.drag_lower_limit = 0
@@ -123,8 +124,10 @@ class WindowingSlider(QWidget):
         self.drag_lower_offset = 0
 
         # Generate the histogram
-        self.initialise_density_histogram()
-        self.update_density_histogram()
+        disable_histogram = True  # turning off because performance is not acceptable
+        if not disable_histogram:
+            self.initialise_density_histogram()
+            self.update_density_histogram()
 
     def set_action_handler(self, action_handler):
         """
@@ -140,19 +143,18 @@ class WindowingSlider(QWidget):
         self.dicom_view.windowing_slider = self
 
     def resizeEvent(self, event):
-        self.histogram.setPlotArea(
-            QtCore.QRectF(0, 0, self.fixed_width-10, event.size().height()))
+        self.histogram.setPlotArea(QtCore.QRectF(0, 0, self.fixed_width - 10, event.size().height()))
 
     def height_to_index(self, pos):
         """
         Converts graph coordinates to a slider index
         :param pos: a local coordinate on the graph
         """
-        index = self.slider_density-1-int(pos/(self.height()/self.slider_density))
+        index = self.slider_density - 1 - int(pos / (self.height() / self.slider_density))
         if index < 0:
             return 0
         if index >= self.slider_density:
-            return self.slider_density-1
+            return self.slider_density - 1
         return index
 
     def window_to_index(self, val):
@@ -182,10 +184,8 @@ class WindowingSlider(QWidget):
         :param level: the level value of the preset
         """
         level = level + WindowingSlider.LEVEL_OFFSET
-        self.update_bar(
-            self.window_to_index(level - window * 0.5), top_bar=True)
-        self.update_bar(
-            self.window_to_index(level + window * 0.5), top_bar=False)
+        self.update_bar(self.window_to_index(level - window * 0.5), top_bar=True)
+        self.update_bar(self.window_to_index(level + window * 0.5), top_bar=False)
 
     def set_density_histogram(self, densities):
         """
@@ -195,9 +195,9 @@ class WindowingSlider(QWidget):
         """
         self.histogram.removeSeries(self.density)
         self.density = QLineSeries()
-        self.density.setColor("grey")
+        self.density.setColor('grey')
         for i in range(0, len(densities)):
-            self.density.append(2-densities[i], i)
+            self.density.append(2 - densities[i], i)
         self.histogram.addSeries(self.density)
 
     def update_density_histogram(self):
@@ -205,6 +205,13 @@ class WindowingSlider(QWidget):
         Updates the histogram display.
         """
         slice_index = self.slice_slider.value()
+        # self.densities won't be set if (CT) initialise_density_histogram() hasn't been called
+        # and it's been turned off because of performance issues.  However, this is a useful
+        # guard even if CT histogram feature gets turned back on.  And may provide
+        # a useful way to deal with lazy histogram calculation if we decide to do that and
+        # turn it back on.
+        if not self.densities:
+            return
         histogram_values = self.densities[slice_index]
         self.set_density_histogram(histogram_values)
 
@@ -224,7 +231,7 @@ class WindowingSlider(QWidget):
                 p = min(pixel, WindowingSlider.MAX_PIXEL_VALUE)
                 p = max(p, 0)
                 p = round(p)
-                if p>=0 and p < WindowingSlider.MAX_PIXEL_VALUE:
+                if p >= 0 and p < WindowingSlider.MAX_PIXEL_VALUE:
                     self.densities[s][p] += 1
             max_value = max(self.densities[s])
             min_value = min(self.densities[s])
@@ -246,22 +253,18 @@ class WindowingSlider(QWidget):
 
         # Clamp index to range
         index = max(index, 0)
-        index = min(index, self.slider_density-1)
+        index = min(index, self.slider_density - 1)
 
         if top_bar:
-            self.slider_bars[self.top].setColor("white")
+            self.slider_bars[self.top].setColor('white')
             self.top = index
-            self.slider_bars[index].setColor("red")
+            self.slider_bars[index].setColor('red')
         else:
             # Ensure the bottom bar is actually rendered
             # Functionally the bar will still be correct
-            self.slider_bars[
-                max(self.bottom, WindowingSlider.MIN_BOTTOM_INDEX)
-                ].setColor("white")
+            self.slider_bars[max(self.bottom, WindowingSlider.MIN_BOTTOM_INDEX)].setColor('white')
             self.bottom = index
-            self.slider_bars[
-                max(index, WindowingSlider.MIN_BOTTOM_INDEX)
-                ].setColor("red")
+            self.slider_bars[max(index, WindowingSlider.MIN_BOTTOM_INDEX)].setColor('red')
 
     def set_bars(self, top_index, bottom_index):
         """
@@ -289,7 +292,7 @@ class WindowingSlider(QWidget):
         if min_dist > WindowingSlider.MAX_CLICK_DIST:
             # Check for middle drag
             if index - self.top > 0 or index - self.bottom > 0:
-                self.selected_bar = "middle"
+                self.selected_bar = 'middle'
                 self.mouse_held = True
                 self.drag_start = index
                 self.drag_upper_limit = self.slider_density - self.top
@@ -300,9 +303,9 @@ class WindowingSlider(QWidget):
 
         self.mouse_held = True
         if dist_to_top < dist_to_bottom:
-            self.selected_bar = "top"
+            self.selected_bar = 'top'
         else:
-            self.selected_bar = "bottom"
+            self.selected_bar = 'bottom'
 
     def mouse_move(self, event):
         """
@@ -331,7 +334,8 @@ class WindowingSlider(QWidget):
             True,
             False,
             False,
-            False]
+            False,
+        ]
 
         top_bar = self.index_to_window(self.top)
         bottom_bar = self.index_to_window(self.bottom)
@@ -342,19 +346,18 @@ class WindowingSlider(QWidget):
 
         with wait_cursor():
             windowing_model_direct(level, window, send)
-            if self.action_handler is not None:    
+            if self.action_handler is not None:
                 self.action_handler.update_views()
             pass
-
 
     def update_bar_position(self, event):
         # move selected bar to the closest valid position
         index = int(self.height_to_index(event.position().y()))
-        if self.selected_bar == "top":
+        if self.selected_bar == 'top':
             if index <= self.bottom:
                 index = self.bottom + 1
             self.update_bar(index, top_bar=True)
-        elif self.selected_bar == "bottom":
+        elif self.selected_bar == 'bottom':
             if index >= self.top:
                 index = self.top - 1
             self.update_bar(index, top_bar=False)


### PR DESCRIPTION
Also 
guard against missing SeriesInstanceUID when loading (skip slice):  Found this in data on a patient CD (my own...)
temporarily incorporate "Missing StudyID" when it is missing (much anonymised data is missing it).

## Summary by Sourcery

Improve DICOM loading resilience, streamline ROI coordinate mapping, and disable the CT density histogram to address performance and missing metadata issues.

Bug Fixes:
- Skip slices missing SeriesInstanceUID during directory traversal to avoid crashes.
- Inject a placeholder StudyID (‘MissingStudyID’) and warn when loading anonymized data without StudyID.

Enhancements:
- Disable CT density histogram rendering by default to improve UI responsiveness.
- Optimize calculate_matrix logic to use vectorized numpy operations and linspace for faster coordinate map computation.
- Improve ImageLoader error handling and progress reporting for DICOM class validation and DVH checking.