### PR TITLE
Fixed Missing Else bug causing QMessageBox to not display

### DIFF
--- a/src/View/ImageFusion/ImageFusionProgressWindow.py
+++ b/src/View/ImageFusion/ImageFusionProgressWindow.py
@@ -42,7 +42,7 @@ class ImageFusionProgressWindow(ProgressWindow):
                 self.signal_advise_calc_dvh.emit(True)
             else:
                 self.signal_advise_calc_dvh.emit(False)
-
+        else:
             # Create a message box and add attributes
             mb = QMessageBox()
             mb.setIcon(QMessageBox.Question)

--- a/src/View/OpenPatientProgressWindow.py
+++ b/src/View/OpenPatientProgressWindow.py
@@ -41,7 +41,7 @@ class OpenPatientProgressWindow(ProgressWindow):
                 self.signal_advise_calc_dvh.emit(True)
             else:
                 self.signal_advise_calc_dvh.emit(False)
-
+        else:
             # Create a message box and add attributes
             mb = QMessageBox()
             mb.setIcon(QMessageBox.Question)

--- a/src/View/mainpage/DVHTab.py
+++ b/src/View/mainpage/DVHTab.py
@@ -186,7 +186,7 @@ class DVHTab(QtWidgets.QWidget):
                 progress_window.exec_()
 
                 self.export_rtdose()
-
+        else:
             # Create a message box and add attributes
             mb = QtWidgets.QMessageBox()
             mb.setIcon(QtWidgets.QMessageBox.Question)


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Add missing else statements in ImageFusionProgressWindow, OpenPatientProgressWindow, and DVHTab to properly instantiate and display QMessageBox