### PR TITLE
Update to stylesheets, Made StyleSheetReader Singleton

### DIFF
--- a/res/stylesheet-win-linux.qss
+++ b/res/stylesheet-win-linux.qss
@@ -1,11 +1,23 @@
 QMainWindow {
-    background-color: rgb(244, 245, 245);
+    background-color: #F5F4F5;
+}
+
+QWidget {
+    background-color: #F5F4F5;
+}
+
+QMenu {
+    color: #000000
+}
+
+QMenuBar {
+    color: #000000
 }
 
 QProgressBar {
     border-radius: 1px;
     background-color: #b299e6;
-    color: rgb(230, 230, 235);
+    color: #e6e6eb;
     max-height: 32px;
     text-align: center;
     font-weight: semi-bold;
@@ -53,8 +65,9 @@ QCheckBox::indicator:indeterminate:pressed {
 }
 
 QLabel {
-    color: black;
+    color: #000000;
 }
+
 QLabel[QLabelClass="window-title"] {
     margin: 8px;
     padding: 4px;
@@ -74,7 +87,7 @@ ROINameCleaningPrefixLabel {
     margin: 4px;
     padding: 0 4px;
     font-size: 14px;
-    background-color: rgb(244, 245, 245);
+    background-color: #F5F4F5;;
 }
 
 ROINameCleaningPrefixLabel:disabled {
@@ -206,7 +219,7 @@ QLineEdit {
     border-bottom: 3px solid #b3b3b3;
     border-radius: 0;
     font-size: 14px;
-    background-color: rgb(244, 245, 245);
+    background-color: #F5F4F5;;
 }
 
 QLineEdit#BatchROICleaning {
@@ -229,11 +242,11 @@ QLineEdit#ImageSliceNumberLineEdit,
 }
 
 QLineEdit:disabled {
-    background-color: #b9b9b9;
-    color: black;
+    background-color: #e6e6eb;
+    color: #000000;
 }
 QLineEdit:hover {
-    background-color: rgb(230, 230, 235);
+    background-color: #e6e6eb;
     border-bottom: 3px solid #9370DB;
 }
 QLineEdit:focus {
@@ -246,6 +259,7 @@ QTreeView#OpenPatientWindowPatientsTree {
 }
 QHeaderView {
     color: red;
+    background-color: #e6e6eb
 }
 QTreeView::item {
     color: #000000;
@@ -253,13 +267,13 @@ QTreeView::item {
     font-size: 14px;
 }
 QTreeView::item:selected:focus {
-    background-color: #ffffff;
-    color: black;
+    background-color: #e6e6eb;
+    color: #000000;
     border: 2px solid #9370DB;
 }
 QTreeView::item:selected:!focus {
     background-color: #5c2eb8;
-    color: white;
+    color: #ffffff;
     border: 2px solid #9370DB;
 }
 QTreeView::item:hover:!focus:!selected, QTreeView::item:hover:selected {
@@ -301,6 +315,13 @@ QTreeView::branch:open:has-children:has-siblings  {
         image: url('./res/images/qtree/collapse-tree.png');
 }
 
+QTabWidget {
+    color: #000000
+}
+
+QTabBar {
+    color: #000000
+}
 
 QTabWidget::tab-bar {
     alignment: left;
@@ -308,10 +329,10 @@ QTabWidget::tab-bar {
 QTabWidget::pane {
     border: 0;
     padding-top: 2px;
-    background-color: white;
+    background-color: #ffffff;
 }
 QTabBar {
-    background-color: rgb(244, 245, 245);
+    background-color: #F5F4F5;;
 }
 QTabBar::tab {
     border-top: 0;
@@ -320,7 +341,7 @@ QTabBar::tab {
     border-left: 0;
     margin: 0;
     padding: 0 12px;
-    background-color: rgb(244, 245, 245);
+    background-color: #F5F4F5;;
     text-align: center;
     height: 36px;
     width: 100%;
@@ -333,22 +354,21 @@ QTabBar::tab:pressed {
     background-color: #5c2eb8;
 }
 QTabBar::tab:selected {
-    background-color: white;
+    background-color: #ffffff;
     border-bottom: 3px solid #5c2eb8;
 }
-
 
 QTabWidget::pane#batch-tabs {
     border: 0;
     padding-top: 2px;
-    background-color: white;
+    background-color: #ffffff;
 }
 QTabBar#batch-tabs {
-    background-color: rgb(244, 245, 245);
+    background-color: #F5F4F5;;
 }
 QTabBar::tab#batch-tabs {
     padding: 0 10px;
-    background-color: rgb(244, 245, 245);
+    background-color: #F5F4F5;;
     text-align: center;
     width: 36px;
     height: 150px;
@@ -359,7 +379,7 @@ QTabBar::tab:selected#batch-tabs {
 
 
 QToolBar, QToolButton {
-    background-color: rgb(244, 245, 245);
+    background-color: #F5F4F5;;
     border: 0;
     margin: 0;
     padding: 2px;
@@ -382,8 +402,8 @@ QComboBox, QDateEdit {
     border-bottom: 3px solid #b3b3b3;
     border-radius: 0;
     font-size: 14px;
-    background-color: rgb(244, 245, 245);
-    color: black;
+    background-color: #F5F4F5;;
+    color: #000000;
 }
 
 QComboBox#BatchROICleaning {
@@ -401,7 +421,7 @@ QComboBox:!hover:!focus, QDateEdit:!hover:!focus {
 }
 QComboBox:hover:!focus, QComboBox:hover:focus,
  QDateEdit:hover:!focus, QDateEdit:hover:focus{
-    background-color: rgb(230, 230, 235);
+    background-color: #e6e6eb;
     border-bottom: 3px solid #b299e6;
 }
 QComboBox:focus:!hover, QDateEdit:focus:!hover {
@@ -409,7 +429,7 @@ QComboBox:focus:!hover, QDateEdit:focus:!hover {
 }
 QComboBox:hover:on:!focus, QComboBox:focus:on:!hover,
  QDateEdit:hover:on:!focus, QDateEdit:focus:on:!hover{
-    background: rgb(230, 230, 235);
+    background: #e6e6eb;
     border-bottom: 3px solid #5c2eb8;
 }
 QComboBox::drop-down, QDateEdit::drop-down {
@@ -423,20 +443,20 @@ QComboBox::down-arrow, QDateEdit::down-arrow {
 
 QComboBox#DicomTreeviewComboBox {
     margin: 0;
-    background-color: white;
-    color: black
+    background-color: #ffffff;
+    color: #000000
 }
 
 
 QCalendarWidget QTableView, QTableView {
-    background-color: white;
-    color: black;
-    alternate-background-color: rgb(230, 230, 235);
+    background-color: #ffffff;
+    color: #000000;
+    alternate-background-color: #e6e6eb;
     selection-background-color: #b299e6;
 }
 QCalendarWidget QMenu {
-    color: black;
-    background-color: white;
+    color: #000000;
+    background-color: #ffffff;
 }
 QCalendarWidget QMenu::item {
     padding: 8px 4px 8px 4px;
@@ -448,22 +468,22 @@ QCalendarWidget QMenu::item:selected {
     background-color: #b299e6;
 }
 QCalendarWidget QMenu::item:pressed {
-    color: white;
+    color: #ffffff;
     background-color: #5c2eb8;
 }
 QCalendarWidget QSpinBox {
-    color: black;
-    background-color: white;
-    selection-color: white;
+    color: #000000;
+    background-color: #ffffff;
+    selection-color: #ffffff;
     selection-background-color: #5c2eb8;
 }
 QCalendarWidget QToolButton {
-    background-color: rgb(230, 230, 235);
-    color:black;
+    background-color: #e6e6eb;
+    color:#000000;
     font-size: 14px;
 }
 QCalendarWidget QToolButton:hover:!focus {
-    background-color: rgb(215, 215, 220);
+    background-color: #d7d7dc;
 }
 QCalendarWidget QToolButton:focus:!hover {
     border: 1px solid #5c2eb8;
@@ -472,8 +492,8 @@ QCalendarWidget QToolButton:pressed:hover:!focus {
     background-color: #b299e6;
 }
 QCalendarWidget QWidget#qt_calendar_navigationbar {
-    background-color: rgb(230, 230, 235);
-    color: black;
+    background-color: #e6e6eb;
+    color: #000000;
 }
 QCalendarWidget QToolButton#qt_calendar_prevmonth {
     icon-size: 24px;
@@ -495,10 +515,10 @@ QWidget#DeleteRoiWindowDeleteWidget {
     background-color: #d32f2f ;
 }
 QWidget#ScrollAreaWidgetContents {
-    background-color: rgb(244, 245, 245);
+    background-color: #F5F4F5;;
 }
 QSlider::groove:horizontal {
-    border:0px solid #bbb;
+    border:0px solid #bbbbbb;
     border-radius: 7px;
 }
 
@@ -511,14 +531,14 @@ QSlider::sub-page:horizontal {
 
 QSlider::add-page:horizontal {
     background: #dadbdb;
-    border: 0px solid #777;
+    border: 0px solid #777777;
     border-radius: 7px;
     margin-top:5px;
     margin-bottom:5px;
 }
 
 QSlider::handle:horizontal {
-    background: rgb(253, 253, 254);
+    background: #fdfdfe;
     width: 10px;
     border: 1px solid #bbbbbb;
     border-radius: 5px;
@@ -535,7 +555,7 @@ QSlider::handle:horizontal:disabled {
 }
 
 QSlider::handle:vertical {
-    background-color: rgb(253, 253, 254);
+    background-color: #fdfdfe;
     border: 1px solid #bbbbbb;
     border-radius: 10px;
 }
@@ -554,14 +574,14 @@ QSlider::add-page:vertical {
 QRadioButton#FusionModeRadio {
     font-family: "Segoe UI", "Roboto", "Helvetica Neue", sans-serif;
     font-size: 16px;
-    color: black;
+    color: #000000;
     font-weight: semi-bold;
 }
 
 QLabel#FusionModeLabel {
     font-family: "Segoe UI", "Roboto", "Helvetica Neue", sans-serif;
     font-size: 16px;
-    color: black;
+    color: #000000;
     font-weight: bold;
 }
 

--- a/res/stylesheet.qss
+++ b/res/stylesheet.qss
@@ -7,6 +7,14 @@ QWidget {
     background-color:  #F5F4F5;
 }
 
+QMenu {
+    color: #000000
+}
+
+QMenuBar {
+    color: #000000
+}
+
 QProgressBar {
     border-radius: 1px;
     background-color: #b299e6;

--- a/res/stylesheet.qss
+++ b/res/stylesheet.qss
@@ -1,11 +1,16 @@
 QMainWindow {
-    background-color: rgb(244, 245, 245);
+    background-color:  #F5F4F5;
+}
+
+QWidget {
+    color: #000000;
+    background-color:  #F5F4F5;
 }
 
 QProgressBar {
     border-radius: 1px;
     background-color: #b299e6;
-    color: rgb(230, 230, 235);
+    color: #e6e6eb;
     max-height: 32px;
     text-align: center;
     font-weight: semi-bold;
@@ -19,9 +24,8 @@ QCheckBox {
     spacing: 5px;
 }
 
-
 QLabel {
-    color: black;
+    color: #000000;
 }
 QLabel[QLabelClass="window-title"] {
     margin: 8px;
@@ -42,7 +46,7 @@ ROINameCleaningPrefixLabel {
     margin: 4px;
     padding: 0 4px;
     font-size: 14px;
-    background-color: rgb(244, 245, 245);
+    background-color:  #F5F4F5;
 }
 
 ROINameCleaningPrefixLabel:disabled {
@@ -173,7 +177,7 @@ QLineEdit {
     border-bottom: 3px solid #b3b3b3;
     border-radius: 0;
     font-size: 14px;
-    background-color: rgb(244, 245, 245);
+    background-color:  #F5F4F5;
 }
 QLineEdit#BatchROICleaning {
     min-height: 34px;
@@ -193,11 +197,11 @@ QLineEdit#ImageSliceNumberLineEdit,
     min-height: 28px;
 }
 QLineEdit:disabled {
-    background-color: #b9b9b9;
-    color: black;
+    background-color: #e6e6eb;
+    color: #000000;
 }
 QLineEdit:hover {
-    background-color: rgb(230, 230, 235);
+    background-color: #e6e6eb;
     border-bottom: 3px solid #9370DB;
 }
 QLineEdit:focus {
@@ -224,15 +228,22 @@ QTreeView::item:focus:!hover {
 }
 QTreeView::item:selected:hover:!focus, QTreeView::item:selected:hover {
     background-color: #5c2eb8;
-    color: white;
-    border: 2px solid rgb(200, 200, 200);
+    color: #ffffff;
+    border: 2px solid #c8c8c8;
 }
 QTreeView::item:selected:!hover:focus {
     background-color: #5c2eb8;
-    color: white;
+    color: #ffffff;
     border: 2px solid #9370DB;
 }
 
+QTabWidget {
+    color: #000000
+}
+
+QTabBar {
+    color: #000000
+}
 
 QTabWidget::tab-bar {
     alignment: left;
@@ -240,10 +251,10 @@ QTabWidget::tab-bar {
 QTabWidget::pane {
     border: 0;
     padding-top: 2px;
-    background-color: white;
+    background-color: #ffffff;
 }
 QTabBar {
-    background-color: rgb(244, 245, 245);
+    background-color:  #F5F4F5;
 }
 QTabBar::tab {
     border-top: 0;
@@ -252,7 +263,7 @@ QTabBar::tab {
     border-left: 0;
     margin: 0;
     padding: 0 12px;
-    background-color: rgb(244, 245, 245);
+    background-color:  #F5F4F5;
     text-align: center;
     height: 36px;
     width: 100%;
@@ -268,7 +279,7 @@ QTabBar::tab:pressed {
     background-color: #5c2eb8;
 }
 QTabBar::tab:selected {
-    background-color: white;
+    background-color: #ffffff;
     border-bottom: 3px solid #5c2eb8;
 }
 
@@ -276,14 +287,14 @@ QTabBar::tab:selected {
 QTabWidget::pane#batch-tabs {
     border: 0;
     padding-top: 2px;
-    background-color: white;
+    background-color: #ffffff;
 }
 QTabBar#batch-tabs {
-    background-color: rgb(244, 245, 245);
+    background-color:  #F5F4F5;
 }
 QTabBar::tab#batch-tabs {
     padding: 0 10px;
-    background-color: rgb(244, 245, 245);
+    background-color:  #F5F4F5;
     text-align: center;
     width: 36px;
     height: 150px;
@@ -294,7 +305,7 @@ QTabBar::tab:selected#batch-tabs {
 
 
 QToolBar, QToolButton {
-    background-color: rgb(244, 245, 245);
+    background-color:  #F5F4F5;
     border: 0;
     margin: 0;
     padding: 2px;
@@ -317,8 +328,8 @@ QComboBox, QDateEdit {
     border-bottom: 3px solid #b3b3b3;
     border-radius: 0;
     font-size: 14px;
-    background-color: rgb(244, 245, 245);
-    color: black;
+    background-color:  #F5F4F5;
+    color: #000000;
 }
 
 QComboBox#BatchROICleaning {
@@ -336,7 +347,7 @@ QComboBox:!hover:!focus, QDateEdit:!hover:!focus {
 }
 QComboBox:hover:!focus, QComboBox:hover:focus,
  QDateEdit:hover:!focus, QDateEdit:hover:focus{
-    background-color: rgb(230, 230, 235);
+    background-color: #e6e6eb;
     border-bottom: 3px solid #b299e6;
 }
 QComboBox:focus:!hover, QDateEdit:focus:!hover {
@@ -344,27 +355,27 @@ QComboBox:focus:!hover, QDateEdit:focus:!hover {
 }
 QComboBox:hover:on:!focus, QComboBox:focus:on:!hover,
  QDateEdit:hover:on:!focus, QDateEdit:focus:on:!hover{
-    background: rgb(230, 230, 235);
+    background: #e6e6eb;
     border-bottom: 3px solid #5c2eb8;
 }
 
 
 QComboBox#DicomTreeviewComboBox {
     margin: 0;
-    background-color: white;
-    color: black;
+    background-color: #ffffff;
+    color: #000000;
 }
 
 
 QCalendarWidget QTableView, QTableView {
-    background-color: white;
-    color: black;
-    alternate-background-color: rgb(230, 230, 235);
+    background-color: #ffffff;
+    color: #000000;
+    alternate-background-color: #e6e6eb;
     selection-background-color: #b299e6;
 }
 QCalendarWidget QMenu {
-    color: black;
-    background-color: white;
+    color: #000000;
+    background-color: #ffffff;
 }
 QCalendarWidget QMenu::item {
     padding: 8px 4px 8px 4px;
@@ -376,22 +387,22 @@ QCalendarWidget QMenu::item:selected {
     background-color: #b299e6;
 }
 QCalendarWidget QMenu::item:pressed {
-    color: white;
+    color: #ffffff;
     background-color: #5c2eb8;
 }
 QCalendarWidget QSpinBox {
-    color: black;
-    background-color: white;
-    selection-color: white;
+    color: #000000;
+    background-color: #ffffff;
+    selection-color: #ffffff;
     selection-background-color: #5c2eb8;
 }
 QCalendarWidget QToolButton {
-    background-color: rgb(230, 230, 235);
-    color:black;
+    background-color: #e6e6eb;
+    color:#000000;
     font-size: 14px;
 }
 QCalendarWidget QToolButton:hover:!focus {
-    background-color: rgb(215, 215, 220);
+    background-color: #d7d7dc;
 }
 QCalendarWidget QToolButton:focus:!hover {
     border: 1px solid #5c2eb8;
@@ -400,8 +411,8 @@ QCalendarWidget QToolButton:pressed:hover:!focus {
     background-color: #b299e6;
 }
 QCalendarWidget QWidget#qt_calendar_navigationbar {
-    background-color: rgb(230, 230, 235);
-    color: black;
+    background-color: #e6e6eb;
+    color: #000000;
 }
 
 QWidget#DeleteRoiWindowKeepWidget, QWidget#DeleteRoiWindowDeleteWidget {
@@ -415,7 +426,7 @@ QWidget#DeleteRoiWindowDeleteWidget {
     background-color: #d32f2f ;
 }
 QWidget#ScrollAreaWidgetContents {
-    background-color: rgb(244, 245, 245);
+    background-color:  #F5F4F5;
 }
 QSlider::groove:horizontal {
     border:0px solid #bbb;
@@ -438,7 +449,7 @@ QSlider::add-page:horizontal {
 }
 
 QSlider::handle:horizontal {
-    background: rgb(253, 253, 254);
+    background: #fdfdfe;
     width: 10px;
     border: 1px solid #bbbbbb;
     border-radius: 5px;
@@ -455,7 +466,7 @@ QSlider::handle:horizontal:disabled {
 }
 
 QSlider::handle:vertical {
-    background-color: rgb(253, 253, 254);
+    background-color: #fdfdfe;
     border: 1px solid #bbbbbb;
     border-radius: 10px;
 }

--- a/src/Controller/ActionHandler.py
+++ b/src/Controller/ActionHandler.py
@@ -6,6 +6,7 @@ from src.Model.PatientDictContainer import PatientDictContainer
 from src.Model.MovingDictContainer import MovingDictContainer
 from src.Model.PTCTDictContainer import PTCTDictContainer
 from src.Controller.PathHandler import resource_path
+from src.View.StyleSheetReader import StyleSheetReader
 from src.View.WindowingUI import Windowing
 from src.Model.Windowing import windowing_model
 
@@ -209,6 +210,7 @@ class ActionHandler:
             QtGui.QIcon.On,
         )
         self.menu_export = QtWidgets.QMenu()
+        self.menu_export.setStyleSheet(StyleSheetReader().get_stylesheet())
         self.menu_export.setTitle("Export")
         self.menu_export.addAction(self.action_pyradiomics_export)
         self.menu_export.addAction(self.action_dvh_export)

--- a/src/View/StyleSheetReader.py
+++ b/src/View/StyleSheetReader.py
@@ -4,6 +4,7 @@ import logging
 import functools
 
 from src.Controller.PathHandler import resource_path
+from src.Model.Singleton import Singleton
 
 logger = logging.getLogger(__name__)
 
@@ -14,7 +15,7 @@ def get_stylesheet() -> str:
     """
     return StyleSheetReader().get_stylesheet()
 
-class StyleSheetReader:
+class StyleSheetReader(metaclass=Singleton):
     """
     A class to hold the style sheet data to be used in the User Interface classes.
     As this information will need to be used for most of the User Interfaces
@@ -66,4 +67,6 @@ class StyleSheetReader:
         :rtype: str
         """
         logger.debug("Reading the style sheet for the User Interface")
-        return pathlib.Path(resource_path(self._get_platform_stylesheet(platform.system()))).read_text()
+        location = self._get_platform_stylesheet(platform.system())
+        logger.debug(f"Reading the style sheet from {location}")
+        return pathlib.Path(resource_path(location)).read_text()

--- a/src/View/mainpage/MenuBar.py
+++ b/src/View/mainpage/MenuBar.py
@@ -5,12 +5,15 @@ from PySide6.QtCore import Qt
 
 from src.Controller.ActionHandler import ActionHandler
 from src.Model.PatientDictContainer import PatientDictContainer
+from src.View.StyleSheetReader import StyleSheetReader
 
 
 class MenuBar(QtWidgets.QMenuBar):
 
     def __init__(self, action_handler: ActionHandler):
         QtWidgets.QMenuBar.__init__(self)
+        stylesheet = StyleSheetReader()
+        self.setStyleSheet(stylesheet.get_stylesheet())
         self.action_handler = action_handler
         self.patient_dict_container = PatientDictContainer()
         self.setGeometry(QtCore.QRect(0, 0, 901, 35))
@@ -19,10 +22,12 @@ class MenuBar(QtWidgets.QMenuBar):
         # Menu Bar: File, Tools, Export, Help
         self.menu_file = QtWidgets.QMenu()
         self.menu_file.setTitle("File")
+        self.menu_file.setStyleSheet(stylesheet.get_stylesheet())
         self.addMenu(self.menu_file)
 
         self.menu_tools = QtWidgets.QMenu()
         self.menu_tools.setTitle("Tools")
+        self.menu_tools.setStyleSheet(stylesheet.get_stylesheet())
         self.addMenu(self.menu_tools)
 
         self.addMenu(self.action_handler.menu_export)


### PR DESCRIPTION
Update to stylesheets, Made StyleSheetReader Singleton
Stylesheet update to work in dark mode setup - forced it to always be the same colours 

Made StyleSheetReader Singleton
So it always calls the same method call which is cached. As before it was singleton each get_stylesheet() call would have a different `self` input causing a new read of the style sheet.

## Summary by Sourcery

Improve stylesheet management by making StyleSheetReader a singleton, enhancing logging, and consistently applying the stylesheet across menu components

Enhancements:
- Convert StyleSheetReader to a singleton to cache stylesheet loading
- Add debug logging of the stylesheet file path when reading
- Apply the shared stylesheet to the main menu bar and its menu items including File, Tools, and Export