### PR TITLE
Adds check for non Axially aligned slices on load and closes segmentation window on completion

### DIFF
--- a/src/Controller/AutoSegmentationController.py
+++ b/src/Controller/AutoSegmentationController.py
@@ -145,18 +145,15 @@ class AutoSegmentationController(QObject):
 
     @Slot()
     def on_segmentation_finished(self) -> None:
-        # Update the text edit UI
         self.update_progress_text("Loading the RTSTRUCT file")
         load_rtss_file_to_patient_dict(self.patient_dict_container)
         self.update_progress_text("Populating Structures Tab.")
         self.update_structure_list.emit()
-        self.update_progress_text("Structures Loaded")
 
-        # Enable once segmentation complete
-        self._view.enable_start_button()
+        self._view.segmentation_successful_dialog(True)
 
     @Slot()
     def on_segmentation_error(self, error) -> None:
         logging.error(error)
-        # Enable once segmentation complete
-        self._view.enable_start_button()
+
+        self._view.segmentation_successful_dialog(False)

--- a/src/Controller/PathHandler.py
+++ b/src/Controller/PathHandler.py
@@ -2,8 +2,10 @@ import os
 import sys
 import re
 from pathlib import Path
-import sys
 
+import logging
+
+logger = logging.getLogger(__name__)
 
 def resource_path(relative_path, sanitizing=False):
     """
@@ -83,3 +85,25 @@ def database_path() -> Path:
     """
 
     return Path.home().joinpath('.OnkoDICOM', 'OnkoDICOM.db')
+
+def delete_files(file_list: list) -> list:
+    """
+    Attempts to delete a list of files and tracks deletion failures.
+    Iterates through the provided list of file paths, attempting to delete
+    each file and keeping track of files that could not be deleted.
+
+    Args:
+        file_list: A list of file paths to be deleted.
+
+    Returns:
+        A list of file paths that could not be deleted.
+    """
+    failed = []
+    for file in file_list:
+        try:
+            os.remove(file)
+        except Exception as e:
+            logger.error(f"Failed to delete file {file}: {e}")
+            failed.append(file)
+
+    return failed

--- a/src/Model/AutoSegmentation/AutoSegmentation.py
+++ b/src/Model/AutoSegmentation/AutoSegmentation.py
@@ -93,7 +93,7 @@ class AutoSegmentation:
         """
             Copies the file paths from patient dict to a temporary location for processing.
             This method creates a temporary directory and copies the DICOM files paths
-            into it, excludes rtdose, rtplan, adn rtstruct files.
+            into it, excludes rtdose, rtplan, and rtstruct files.
 
             Raises:
                 ValueError: If the DICOM directory is not set or copying fails.
@@ -137,8 +137,7 @@ class AutoSegmentation:
             task=task,
             roi_subset=list(set(copy.deepcopy(roi_subset))), # Deep copy to prevent changing to the selection after starting
             output_type="nifti",
-            device="gpu",
-            fastest=True
+            device="gpu"
         )
 
     def _convert_to_rtstruct(self, nifti_dir, output_rt) -> None:

--- a/src/Model/AutoSegmentation/AutoSegmentation.py
+++ b/src/Model/AutoSegmentation/AutoSegmentation.py
@@ -26,6 +26,7 @@ class AutoSegmentation:
         patient_dict_container = PatientDictContainer()
         self.dicom_dir = patient_dict_container.path  # Get the current loaded dir to DICOM series
         self.dicom_temp_dir = None
+        self.file_paths = patient_dict_container.filepaths # dict, where keys = slice number/RT modality and values = filepaths
 
         self.signals = SegmentationWorkerSignals()
 
@@ -90,25 +91,31 @@ class AutoSegmentation:
 
     def _copy_temp_dicom_dir(self) -> None:
         """
-        Copies the DICOM directory to a temporary location for processing.
-        This method creates a temporary directory and copies the DICOM files
-        into it, excluding RTSTRUCT files.
+            Copies the file paths from patient dict to a temporary location for processing.
+            This method creates a temporary directory and copies the DICOM files paths
+            into it, excludes rtdose, rtplan, adn rtstruct files.
 
-        Raises:
-            ValueError: If the DICOM directory is not set or copying fails.
-        """
-        if not self.dicom_dir:
-            raise ValueError(f"No dicom directory found: {self.dicom_dir!r}")
+            Raises:
+                ValueError: If the DICOM directory is not set or copying fails.
+         """
+        if not self.file_paths:
+            raise FileNotFoundError(f"No dicom files found in {self.file_paths}")
+        # Create temporary directory
         self.dicom_temp_dir = tempfile.TemporaryDirectory()
-        try:
-            shutil.copytree(
-                self.dicom_dir,
-                self.dicom_temp_dir.name,
-                ignore=shutil.ignore_patterns("rt*.dcm"),
-                dirs_exist_ok=True,
-            )
-        except Exception as e:
-            raise ValueError(f"Failed to copy DICOM files: {e}") from e
+
+        # Copy each source file to the temporary directory
+        for name, src_file_path in self.file_paths.items():
+
+            # Exclude files
+            if name in ['rtdose', 'rtss', 'rtplan']:
+                continue
+            # Create new file path
+            dest_file_path = os.path.join(self.dicom_temp_dir.name, os.path.basename(src_file_path))
+            try:
+                shutil.copyfile(src_file_path, dest_file_path)
+            except Exception as e:
+                self.signals.error.emit(str(e))
+
 
     def _run_totalsegmentation(self, task, roi_subset, output_dir) -> None:
         """
@@ -131,6 +138,7 @@ class AutoSegmentation:
             roi_subset=list(set(copy.deepcopy(roi_subset))), # Deep copy to prevent changing to the selection after starting
             output_type="nifti",
             device="gpu",
+            fastest=True
         )
 
     def _convert_to_rtstruct(self, nifti_dir, output_rt) -> None:
@@ -171,7 +179,8 @@ class AutoSegmentation:
     def _cleanup_temp_dir(self) -> None:
         """
         Cleans up the temporary DICOM directory if it exists.
-        This method ensures that any temporary directory created for DICOM files is properly removed after processing.
+        This method ensures that any temporary directory created
+        for DICOM files is properly removed after processing.
 
         Returns:
             None

--- a/src/Model/ImageLoading.py
+++ b/src/Model/ImageLoading.py
@@ -190,7 +190,9 @@ def get_datasets(filepath_list, file_type=None, parent_window=None):
             read_file = dcmread(file)
 
         if read_file.SOPClassUID not in allowed_classes:
-            raise NotAllowedClassError
+            raise NotAllowedClassError(
+                f"File '{file}' has disallowed SOPClassUID '{read_file.SOPClassUID}'"
+            )
 
         allowed_class = allowed_classes[read_file.SOPClassUID]
 

--- a/src/Model/ImageLoading.py
+++ b/src/Model/ImageLoading.py
@@ -234,7 +234,7 @@ def get_datasets(filepath_list, file_type=None, parent_window=None):
     )
 
     # Notify user of abnormal slice alignment on initial load
-    if incorrectly_aligned_slices and type(parent_window) is ImageLoader:
+    if incorrectly_aligned_slices and isinstance(parent_window, ImageLoader):
         parent_window.acknowledged_incorrect_slice = False
         parent_window.incorrect_slice_orientation.emit(incorrectly_aligned_slices)
 

--- a/src/Model/ImageLoading.py
+++ b/src/Model/ImageLoading.py
@@ -134,7 +134,7 @@ def _is_correct_orientation(slice_data: FileDataset) -> bool:
     Determines if a DICOM slice is oriented in an axial plane.
     Checks the orientation of a DICOM slice by calculating its normal vector
     and comparing it to the standard Z-axis. Slices within approximately
-    45 degrees of the axial plane are considered correctly oriented.
+    25 degrees of the axial plane are considered correctly oriented.
 
     Args:
         slice_data: A DICOM FileDataset representing a single slice.

--- a/src/Model/ImageLoading.py
+++ b/src/Model/ImageLoading.py
@@ -160,8 +160,10 @@ def _is_correct_orientation(slice_data: FileDataset) -> bool:
         comp_result = np.dot(img_normal, [0,0,1])
 
         return abs(comp_result) > 0.90
-    except:
-        raise AttributeError
+    except AttributeError as e:
+        logging.error(f"Input missing ImageOrientationPatient attribute: {e}")
+        return False
+
 
 def get_datasets(filepath_list, file_type=None, parent_window=None):
     """

--- a/src/View/AutoSegmentation/AutoSegmentWindow.py
+++ b/src/View/AutoSegmentation/AutoSegmentWindow.py
@@ -1,8 +1,11 @@
 import copy
 from typing import Callable
 from PySide6 import QtWidgets, QtCore
-from PySide6.QtGui import QTextCursor
+from PySide6.QtGui import QTextCursor, QPixmap
 from PySide6.QtCore import QSize
+from PySide6.QtWidgets import QMessageBox
+from src.Controller.PathHandler import resource_path
+from src.View.StyleSheetReader import StyleSheetReader
 
 from src.Model.AutoSegmentation.AutoSegmentViewState import AutoSegmentViewState
 from src.View.AutoSegmentation.ButtonInputBox import ButtonInputBox
@@ -111,6 +114,39 @@ class AutoSegmentWindow(QtWidgets.QWidget):
         self.running: bool = True
         self._start_button.setEnabled(False)
         self._start_button.setText("Wait")
+
+    def segmentation_successful_dialog(self, status: bool) -> None:
+        """
+        Displays a dialog indicating the result of the auto-segmentation process.
+        Shows a message box to inform the user about the success or failure of the
+        auto-segmentation task. On user acknowledgment, it re-enables the start
+        button and closes the window.
+
+        Args:
+            status: Boolean indicating whether the segmentation was successful.
+        """
+        msgbox = QMessageBox()
+        msgbox.setStyleSheet(StyleSheetReader().get_stylesheet())
+        msgbox.setIconPixmap(
+            QPixmap(resource_path('res/images/icon.icns'))
+            .scaledToHeight(100, QtCore.Qt.TransformationMode.SmoothTransformation)
+        )
+        if status:
+            msgbox.setWindowTitle("Auto-Segmentation Successful")
+            msgbox.setText("Auto-Segmentation completed successfully.\n\n"
+                           "The resulting structures have been saved to 'rtss.dcm' in the parent directory.")
+        else:
+            msgbox.setWindowTitle("Auto-Segmentation Failed")
+            msgbox.setText("Auto-Segmentation could not be completed.\n"
+                           "Please see the log file for more information.")
+
+        msgbox.setStandardButtons(QMessageBox.StandardButton.Ok)
+        msgbox.setDefaultButton(QMessageBox.StandardButton.Ok)
+        result = msgbox.exec()
+
+        if result == QMessageBox.StandardButton.Ok:
+            self.enable_start_button()
+            self.close()
 
     def get_segmentation_roi_subset(self) -> list[str]:
         """

--- a/src/View/ImageLoader.py
+++ b/src/View/ImageLoader.py
@@ -38,7 +38,14 @@ class ImageLoader(QtCore.QObject):
         self.calc_dvh = False
         self.advised_calc_dvh = False
 
-    def wait_for_acknowledgment(self):
+    def wait_for_acknowledgment(self) -> None:
+        """
+        Pauses the loading process and waits for user acknowledgment of incorrect slice orientation.
+        This method creates a QEventLoop to block further execution until the user acknowledges 
+        any issues with slice orientation. It connects to a signal from the parent window that 
+        will quit the event loop when triggered.
+        """
+
         from PySide6.QtCore import QEventLoop
         loop = QEventLoop()
 

--- a/src/View/ImageLoader.py
+++ b/src/View/ImageLoader.py
@@ -3,6 +3,7 @@ import os
 import platform
 from pathlib import Path
 
+from PySide6.QtCore import Slot
 from pydicom import dcmread, dcmwrite
 from PySide6 import QtCore
 
@@ -26,6 +27,8 @@ class ImageLoader(QtCore.QObject):
     """
 
     signal_request_calc_dvh = QtCore.Signal()
+    incorrect_slice_orientation = QtCore.Signal(list)
+    incorrect_slices_deleted = QtCore.Signal(list)
 
     def __init__(self, selected_files, existing_rtss, parent_window, *args, **kwargs):
         super(ImageLoader, self).__init__(*args, **kwargs)
@@ -34,6 +37,8 @@ class ImageLoader(QtCore.QObject):
         self.existing_rtss = existing_rtss
         self.calc_dvh = False
         self.advised_calc_dvh = False
+        self.acknowledged_incorrect_slice = True
+        self.parent_window.signal_acknowledge_incorrect_slice.connect(self.acknowledge_incorrect_slice)
 
     def load(self, interrupt_flag, progress_callback):
         """
@@ -48,8 +53,11 @@ class ImageLoader(QtCore.QObject):
             # Gets the common root folder.
             path = os.path.dirname(os.path.commonprefix(self.selected_files))
             read_data_dict, file_names_dict = ImageLoading.get_datasets(
-                self.selected_files
+                self.selected_files, parent_window=self
             )
+            # If incorrect slice found, will loop to await user acknowledgment
+            while not self.acknowledged_incorrect_slice:
+                pass
         except ImageLoading.NotAllowedClassError as e:
             logging.error(f"ImageLoader.load: {repr(e)}")
             raise ImageLoading.NotAllowedClassError from e
@@ -292,3 +300,7 @@ class ImageLoader(QtCore.QObject):
     def update_calc_dvh(self, advice):
         self.advised_calc_dvh = True
         self.calc_dvh = advice
+
+    @Slot()
+    def acknowledge_incorrect_slice(self, value):
+        self.acknowledged_incorrect_slice = value

--- a/src/View/OpenPatientProgressWindow.py
+++ b/src/View/OpenPatientProgressWindow.py
@@ -117,7 +117,7 @@ class OpenPatientProgressWindow(ProgressWindow):
             self.display_files_deleted_result(slices_not_deleted)
 
         else:
-            self.signal_acknowledge_incorrect_slice.emit(True)
+            self.signal_acknowledge_incorrect_slice.emit()
 
     def display_files_deleted_result(self, slices_not_deleted: list) -> None:
         """
@@ -145,4 +145,4 @@ class OpenPatientProgressWindow(ProgressWindow):
         return_value = msgbox.exec_()
 
         if return_value == QMessageBox.StandardButton.Ok:
-            self.signal_acknowledge_incorrect_slice.emit(True)
+            self.signal_acknowledge_incorrect_slice.emit()

--- a/src/View/OpenPatientProgressWindow.py
+++ b/src/View/OpenPatientProgressWindow.py
@@ -1,11 +1,18 @@
+import logging
+import os
 import platform
 from pathlib import Path
+
+from PIL.ImageQt import QPixmap
+from PySide6.QtCore import Slot
 from PySide6.QtWidgets import QMessageBox
 from PySide6 import QtCore, QtGui, QtWidgets
 from src.View.ProgressWindow import ProgressWindow
 from src.View.ImageLoader import ImageLoader
-from src.Controller.PathHandler import resource_path
+from src.Controller.PathHandler import resource_path, delete_files
 from src.View.StyleSheetReader import StyleSheetReader
+
+logger = logging.getLogger(__name__)
 
 
 class OpenPatientProgressWindow(ProgressWindow):
@@ -19,6 +26,9 @@ class OpenPatientProgressWindow(ProgressWindow):
         image_loader = ImageLoader(selected_files, existing_rtss, self)
         image_loader.signal_request_calc_dvh.connect(
             self.prompt_calc_dvh)
+        # Connect slot for incorrect slice detection
+        image_loader.incorrect_slice_orientation.connect(
+            self.prompt_warn_incorrect_slice)
 
         # Start loading the selected files on separate thread
         self.start(image_loader.load)
@@ -69,3 +79,70 @@ class OpenPatientProgressWindow(ProgressWindow):
                 self.signal_advise_calc_dvh.emit(True)
             else:
                 self.signal_advise_calc_dvh.emit(False)
+
+    @Slot()
+    def prompt_warn_incorrect_slice(self, slice_list: list) -> None:
+        """
+        Prompts user about incorrectly aligned DICOM slices.
+        Displays a warning dialog showing non-axially aligned slices and
+        offers the user an option to permanently delete the files.
+        Handles user's choice by either deleting files or acknowledging the issue.
+
+        Args:
+            slice_list: A list of file paths for incorrectly aligned slices.
+        """
+        # Create string of slices
+        slices_str = "\n".join(os.path.basename(slice_path) for slice_path in slice_list)
+
+        # Setup message box
+        msgbox = QMessageBox(self)
+        msgbox.setIconPixmap(QPixmap(resource_path('res/images/icon.icns'))
+                             .scaledToHeight(100, QtCore.Qt.TransformationMode.SmoothTransformation))
+        msgbox.setWindowTitle("Incorrect Slice Alignment")
+        msgbox.setText(f"The following slices are not Axially aligned and have been omitted from the dataset:\n\n {slices_str}\n\n"
+                       f"Would you like to permanently delete the file(s)? \n(Warning, this action is irreversible!)")
+
+        # Add buttons in specific order
+        button_no = QtWidgets.QPushButton("No")
+        button_yes = QtWidgets.QPushButton("Yes")
+        msgbox.addButton(button_no, QtWidgets.QMessageBox.AcceptRole)
+        msgbox.addButton(button_yes, QtWidgets.QMessageBox.RejectRole)
+
+        msgbox.setStyleSheet(StyleSheetReader().get_stylesheet())
+        msgbox.exec_()
+
+        if msgbox.clickedButton() == button_yes:
+            # Call to delete files pass slice_list
+            slices_not_deleted = delete_files(slice_list)
+            self.display_files_deleted_result(slices_not_deleted)
+
+        else:
+            self.signal_acknowledge_incorrect_slice.emit(True)
+
+    def display_files_deleted_result(self, slices_not_deleted: list) -> None:
+        """
+        Displays the result of file deletion attempts.
+        Shows a message box informing the user about the success or failure
+        of deleting incorrectly aligned DICOM slices. Emits a signal to
+        acknowledge the slice orientation issue.
+
+        Args:
+            slices_not_deleted: A list of file paths that could not be deleted.
+        """
+        msgbox = QMessageBox(self)
+        msgbox.setIconPixmap(QPixmap(resource_path('res/images/icon.icns'))
+                             .scaledToHeight(100, QtCore.Qt.TransformationMode.SmoothTransformation)) # Improves scaling on retina displays
+        msgbox.setWindowTitle("Files Deleted")
+
+        if slices_not_deleted:
+            failed_str = "\n".join(os.path.basename(f) for f in slices_not_deleted)
+            msgbox.setText(f"The following file(s) were not deleted:\n\n{failed_str}\n\n"
+                           f"Please manually delete them.")
+        else:
+            msgbox.setText("Files were successfully deleted.")
+
+        msgbox.setStyleSheet(StyleSheetReader().get_stylesheet())
+        return_value = msgbox.exec_()
+
+        if return_value == QMessageBox.StandardButton.Ok:
+            self.signal_acknowledge_incorrect_slice.emit(True)

--- a/src/View/OpenPatientProgressWindow.py
+++ b/src/View/OpenPatientProgressWindow.py
@@ -73,9 +73,9 @@ class OpenPatientProgressWindow(ProgressWindow):
             mb.setStyleSheet(StyleSheetReader().get_stylesheet())
             mb.setWindowIcon(QtGui.QIcon(resource_path(Path.cwd().joinpath(
                 'res', 'images', 'btn-icons', 'onkodicom_icon.png'))))
-            mb.exec_()
+            return_value = mb.exec_()
 
-            if mb.clickedButton() == button_yes:
+            if return_value == button_yes:
                 self.signal_advise_calc_dvh.emit(True)
             else:
                 self.signal_advise_calc_dvh.emit(False)
@@ -109,9 +109,9 @@ class OpenPatientProgressWindow(ProgressWindow):
         msgbox.addButton(button_yes, QtWidgets.QMessageBox.RejectRole)
 
         msgbox.setStyleSheet(StyleSheetReader().get_stylesheet())
-        msgbox.exec_()
+        return_value = msgbox.exec_()
 
-        if msgbox.clickedButton() == button_yes:
+        if return_value == button_yes:
             # Call to delete files pass slice_list
             slices_not_deleted = delete_files(slice_list)
             self.display_files_deleted_result(slices_not_deleted)
@@ -140,6 +140,7 @@ class OpenPatientProgressWindow(ProgressWindow):
                            f"Please manually delete them.")
         else:
             msgbox.setText("Files were successfully deleted.")
+        msgbox.setStandardButtons(QMessageBox.StandardButton.Ok)
 
         msgbox.setStyleSheet(StyleSheetReader().get_stylesheet())
         return_value = msgbox.exec_()

--- a/src/View/ProgressWindow.py
+++ b/src/View/ProgressWindow.py
@@ -21,7 +21,7 @@ class ProgressWindow(QDialog):
     signal_advise_calc_dvh = QtCore.Signal(bool)
 
     # Signal that emits when incorrect slice is acknowledged
-    signal_acknowledge_incorrect_slice = QtCore.Signal(bool)
+    signal_acknowledge_incorrect_slice = QtCore.Signal()
 
     def __init__(self, *args, **kwargs):
         super(ProgressWindow, self).__init__(*args, **kwargs)

--- a/src/View/ProgressWindow.py
+++ b/src/View/ProgressWindow.py
@@ -20,6 +20,9 @@ class ProgressWindow(QDialog):
     # Signal that emits when calc dvh is advised
     signal_advise_calc_dvh = QtCore.Signal(bool)
 
+    # Signal that emits when incorrect slice is acknowledged
+    signal_acknowledge_incorrect_slice = QtCore.Signal(bool)
+
     def __init__(self, *args, **kwargs):
         super(ProgressWindow, self).__init__(*args, **kwargs)
 

--- a/src/View/mainpage/DicomAxialView.py
+++ b/src/View/mainpage/DicomAxialView.py
@@ -244,7 +244,7 @@ class DicomAxialView(DicomView):
 
         # Information to display
         self.current_slice_number = dataset['InstanceNumber'].value
-        total_slices = len(self.patient_dict_container.get("pixmaps_axial"))
+        total_slices = self.patient_dict_container.dataset[len(self.patient_dict_container.get("pixmaps_axial"))-1]['InstanceNumber'].value
         row_img = dataset['Rows'].value
         col_img = dataset['Columns'].value
         window = self.patient_dict_container.get("window")
@@ -258,7 +258,7 @@ class DicomAxialView(DicomView):
 
         # Update labels
         self.label_image_id.setText(
-            "Image: %s / %s" % (str(self.current_slice_number), str(total_slices)))
+            "Instance: %s / %s" % (str(self.current_slice_number), str(total_slices)))
         self.label_image_pos.setText("Position: %s mm" % (str(slice_pos)))
         self.label_wl.setText("W/L: %s/%s" % (str(window), str(level)))
         self.label_image_size.setText(


### PR DESCRIPTION
Add prompt to permanently delete non Axially aligned slices 
Refactored AutoSegmentation.py copy_temp_dicom_dir to copy from loaded patient dictionary file paths 
Adjusted total slices display to match instance numbers - as mismatch occurs when incorrect slice removed 
Added logging to modules as required
Added delete_files to PathHandler.py to facilitate the removal of non Axially aligned slices 
Added segmentation_successful_dialog to display outcome of segmentation task and close window on completion

## Summary by Sourcery

Implement a check for non-axially aligned slices during image loading with user prompt for deletion, refactor the auto-segmentation temp directory copying to leverage patient file paths, refine slice count display to match DICOM instances, and add post-segmentation dialog handling along with logging and file deletion support

New Features:
- Prompt and offer permanent deletion for non-axially aligned DICOM slices on load
- Show a success/failure dialog and close the auto-segmentation window upon segmentation completion

Enhancements:
- Refactor temporary DICOM copying to use patient dict file paths and exclude RT files
- Adjust axial view slice count display to use actual instance numbers
- Add comprehensive logging in image loading and path handling modules
- Introduce delete_files utility for bulk file removal