### PR TITLE
Fix bug - added a missing conditional in ImageLoader.py

### DIFF
--- a/src/Model/ImageLoading.py
+++ b/src/Model/ImageLoading.py
@@ -202,7 +202,6 @@ def get_datasets(filepath_list, file_type=None, parent_window=None):
             incorrectly_aligned_slices.append(file)
             continue
 
-
         is_missing = missing_interop_elements(read_file)
         is_interoperable = len(is_missing) == 0
 
@@ -239,7 +238,7 @@ def get_datasets(filepath_list, file_type=None, parent_window=None):
 
     # Notify user of abnormal slice alignment on initial load
     if incorrectly_aligned_slices and isinstance(parent_window, ImageLoader):
-        parent_window.acknowledged_incorrect_slice = False
+        parent_window.detected_incorrect_slice = True
         parent_window.incorrect_slice_orientation.emit(incorrectly_aligned_slices)
 
     return sorted_read_data_dict, sorted_file_names_dict

--- a/src/Model/ImageLoading.py
+++ b/src/Model/ImageLoading.py
@@ -238,7 +238,7 @@ def get_datasets(filepath_list, file_type=None, parent_window=None):
 
     # Notify user of abnormal slice alignment on initial load
     if incorrectly_aligned_slices and isinstance(parent_window, ImageLoader):
-        parent_window.detected_incorrect_slice = True
+        parent_window.is_incorrect_slice = True
         parent_window.incorrect_slice_orientation.emit(incorrectly_aligned_slices)
 
     return sorted_read_data_dict, sorted_file_names_dict

--- a/src/View/ImageLoader.py
+++ b/src/View/ImageLoader.py
@@ -37,6 +37,7 @@ class ImageLoader(QtCore.QObject):
         self.existing_rtss = existing_rtss
         self.calc_dvh = False
         self.advised_calc_dvh = False
+        self.detected_incorrect_slice = False
 
     def wait_for_acknowledgment(self) -> None:
         """
@@ -70,8 +71,11 @@ class ImageLoader(QtCore.QObject):
             read_data_dict, file_names_dict = ImageLoading.get_datasets(
                 self.selected_files, parent_window=self
             )
-            # If incorrect slice found, will loop to await user acknowledgment
-            self.wait_for_acknowledgment()
+            # Enter ack loop if incorrect slice detected
+            if self.detected_incorrect_slice:
+                # If incorrect slice found, will loop to await user acknowledgment
+                self.wait_for_acknowledgment()
+                self.detected_incorrect_slice = False  # reset boolean
 
         except ImageLoading.NotAllowedClassError as e:
             logging.error(f"ImageLoader.load: {repr(e)}")
@@ -317,5 +321,5 @@ class ImageLoader(QtCore.QObject):
         self.calc_dvh = advice
 
     @Slot()
-    def acknowledge_incorrect_slice(self, value):
-        self.acknowledged_incorrect_slice = value
+    def detected_incorrect_slice(self, value):
+        self.detected_incorrect_slice = value

--- a/src/View/ImageLoader.py
+++ b/src/View/ImageLoader.py
@@ -37,7 +37,7 @@ class ImageLoader(QtCore.QObject):
         self.existing_rtss = existing_rtss
         self.calc_dvh = False
         self.advised_calc_dvh = False
-        self.detected_incorrect_slice = False
+        self.is_incorrect_slice = False
 
     def wait_for_acknowledgment(self) -> None:
         """
@@ -72,10 +72,10 @@ class ImageLoader(QtCore.QObject):
                 self.selected_files, parent_window=self
             )
             # Enter ack loop if incorrect slice detected
-            if self.detected_incorrect_slice:
+            if self.is_incorrect_slice:
                 # If incorrect slice found, will loop to await user acknowledgment
                 self.wait_for_acknowledgment()
-                self.detected_incorrect_slice = False  # reset boolean
+                self.is_incorrect_slice = False  # reset boolean
 
         except ImageLoading.NotAllowedClassError as e:
             logging.error(f"ImageLoader.load: {repr(e)}")
@@ -322,4 +322,4 @@ class ImageLoader(QtCore.QObject):
 
     @Slot()
     def detected_incorrect_slice(self, value):
-        self.detected_incorrect_slice = value
+        self.is_incorrect_slice = value


### PR DESCRIPTION
Fixing bug - conditional check missing from ImageLoader.py that created infinite loop

## Summary by Sourcery

Prevent infinite acknowledgment loop in ImageLoader by introducing a flag to gate the acknowledgment flow and updating signal handling accordingly.

Bug Fixes:
- Fix infinite loop in ImageLoader.load by only entering the acknowledgment loop when an incorrect slice has been detected

Enhancements:
- Add a detected_incorrect_slice boolean flag to ImageLoader to track incorrect slice detection
- Reset detected_incorrect_slice flag after handling user acknowledgment

Chores:
- Rename the slot method to detected_incorrect_slice and update its implementation
- Update get_datasets to set detected_incorrect_slice on the parent ImageLoader instead of the old acknowledged flag